### PR TITLE
Centralize templates styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,212 @@
+/* Styles extracted from templates */
+
+/* Color scheme overrides */
+.card.gradient-blue {
+    background: linear-gradient(135deg, #219CF3, #1976D2) !important;
+    color: white !important;
+}
+.card.gradient-teal {
+    background: linear-gradient(135deg, #00BCD4, #4DD0E1) !important;
+}
+.card.gradient-coral {
+    background: linear-gradient(135deg, #FF8A65, #EF5350) !important;
+    color: white !important;
+}
+.btn.btn-gradient-blue {
+    background: linear-gradient(135deg, #219CF3, #1976D2) !important;
+    color: white !important;
+    border: none !important;
+}
+.btn.btn-gradient-teal {
+    background-color: #00BCD4 !important;
+    color: white !important;
+    border: none !important;
+}
+.btn.btn-yellow {
+    background-color: #FFC107 !important;
+    color: #1976D2 !important;
+    border: none !important;
+    font-weight: bold !important;
+}
+.badge.badge-coral {
+    background-color: #EF5350 !important;
+    color: white !important;
+}
+.text-white-80 {
+    color: rgba(255,255,255,0.8) !important;
+}
+.text-white-90 {
+    color: rgba(255,255,255,0.9) !important;
+}
+.text-yellow {
+    color: #FFC107 !important;
+}
+
+/* Classroom styles */
+.gradient-blue {
+    background: linear-gradient(to bottom right, #1976D2, #2196F3) !important;
+}
+.card {
+    box-shadow: 0px 2px 6px rgba(0,0,0,0.15);
+}
+.rounded-4 {
+    border-radius: 1rem;
+}
+.text-light-muted {
+    color: #E0E0E0 !important;
+}
+.badge-material {
+    background-color: #FFC107 !important;
+    color: #000 !important;
+    font-weight: 600 !important;
+    font-size: 0.75rem !important;
+    padding: 4px 8px !important;
+    border-radius: 0.5rem !important;
+}
+.badge-invite {
+    background-color: #F06292 !important;
+    color: #fff !important;
+    font-weight: 600 !important;
+    font-size: 0.75rem !important;
+    padding: 4px 8px !important;
+    border-radius: 0.5rem !important;
+}
+.modal-content.gradient-blue {
+    background: linear-gradient(to bottom right, #1976D2, #2196F3) !important;
+    color: white !important;
+}
+.modal-content.gradient-blue .form-label,
+.modal-content.gradient-blue .form-text {
+    color: rgba(255, 255, 255, 0.8) !important;
+}
+.modal-content.gradient-blue input[type="text"],
+.modal-content.gradient-blue input[type="file"],
+.modal-content.gradient-blue input[type="email"] {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+    border: 1px solid rgba(255, 255, 255, 0.4) !important;
+    color: white !important;
+}
+.modal-content.gradient-blue input::placeholder {
+    color: rgba(255, 255, 255, 0.6) !important;
+}
+.gradient-purple {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+}
+.gradient-light-blue {
+    background: linear-gradient(135deg, #64B5F6, #42A5F5) !important;
+    color: white !important;
+}
+
+/* Hover style for AI Tools button */
+.list-group-item .dropdown .btn.btn-outline-light:hover {
+    color: #1976D2 !important;
+}
+
+/* Quiz History table text color */
+.card.gradient-teal table,
+.card.gradient-teal th,
+.card.gradient-teal td {
+    color: #333 !important;
+}
+
+/* Delete/remove buttons */
+.list-group-item .btn-outline-danger {
+    background-color: #dc3545 !important;
+    color: white !important;
+    border-color: #dc3545 !important;
+}
+.list-group-item .btn-outline-danger:hover,
+.list-group-item .btn-outline-danger:focus,
+.list-group-item .btn-outline-danger:active {
+    background-color: transparent !important;
+    color: #dc3545 !important;
+    border-color: #dc3545 !important;
+}
+
+/* Quizzes badge styles */
+.badge {
+    display: inline-block;
+    padding: 0.35em 0.65em;
+    font-size: 0.75em;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.25rem;
+    color: #fff !important;
+}
+.badge.badge-primary { background-color: #0d6efd !important; }
+.badge.badge-secondary { background-color: #17d083 !important; color: #000 !important; }
+.badge.badge-success { background-color: #198754 !important; }
+.badge.badge-danger { background-color: #dc3545 !important; }
+.badge.badge-warning { background-color: #ffc107 !important; color: #000 !important; }
+.badge.badge-info { background-color: #0dcaf0 !important; color: #000 !important; }
+.badge.badge-light { background-color: #f8f9fa !important; color: #000 !important; }
+.badge.badge-dark { background-color: #212529 !important; }
+.badge.badge-coral { background-color: #EF5350 !important; color: white !important; }
+
+/* Study guide print styles */
+@media print {
+    .navbar, .card-header, .card-footer, .btn, .row.mt-4 { display: none !important; }
+    .card { border: none !important; background: white !important; color: black !important; }
+    .study-guide-content { color: black !important; }
+    .text-primary, .text-info, .text-warning, .text-white, .text-white-80, .text-white-50, .text-yellow { color: black !important; }
+    .badge { color: black !important; background-color: #eee !important; }
+    .study-guide-content i[data-feather] { color: black !important; }
+}
+
+/* Index page hero styles */
+.bg-gradient-blue { background: linear-gradient(135deg, #2196F3, #1976D2); }
+.bg-gradient-cyan { background: linear-gradient(135deg, #03A9F4, #039BE5); }
+.bg-gradient-red { background: linear-gradient(135deg, #FF8A65, #EF5350); }
+.btn-hero { font-weight: 600; border: none; }
+.btn-hero-start { background: linear-gradient(135deg, #2196F3, #1976D2); color: #fff; }
+.btn-hero-start:hover { background: linear-gradient(135deg, #1976D2, #2196F3); color: #fff; }
+.btn-hero-signin { background-color: #00BCD4; color: #fff; }
+.btn-hero-signin:hover { background-color: #0097A7; color: #fff; }
+
+/* Utility classes for inline styles */
+.icon-48 { width: 48px; height: 48px; }
+.icon-64 { width: 64px; height: 64px; }
+.icon-80 { width: 80px; height: 80px; }
+.icon-40 { width: 40px; height: 40px; }
+.icon-14 { width: 14px; height: 14px; }
+
+.bg-dark-blue { background-color: #0b4e91; }
+.list-bg-dark { background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px; }
+.bg-white-10 { background-color: rgba(255,255,255,0.1); }
+.bg-white-10-border { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); }
+.text-cyan { color: #00BCD4 !important; }
+.text-coral { color: #FF8A65 !important; }
+.text-light-blue { color: #64B5F6 !important; }
+.progress-thin { height: 5px; }
+.progress-thin-6 { height: 6px; background-color: rgba(255,255,255,0.2); }
+.progress-small-container { width: 50px; background-color: rgba(0,0,0,0.1); height: 8px; }
+.progress-bar-yellow { background-color: #FFC107; }
+.code-inline { background-color: rgba(255,255,255,0.2); padding: 2px 8px; border-radius: 4px; }
+.btn-results { background-color: rgba(255,255,255,0.2); color: white; border: 1px solid rgba(255,255,255,0.3); }
+.badge-cyan { background-color: #00BCD4; color: white; }
+.badge-coral-bg { background-color: #FF8A65; color: white; }
+.row-light { border-bottom: 1px solid rgba(0,0,0,0.1); background-color: rgba(255,255,255,0.9); color: #333; }
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.7);
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease;
+}
+
+.icon-medal { font-size: 1.5rem; }
+.bg-white-20 { background-color: rgba(255,255,255,0.2); }
+.maxw-500 { max-width: 500px; }
+

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -5,10 +5,10 @@
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-md-6 col-lg-4">
-        <div class="card border-0 gradient-blue" style="border-radius: 15px;">
+        <div class="card border-0 gradient-blue rounded-4">
             <div class="card-body p-4">
                 <div class="text-center mb-4">
-                    <i data-feather="log-in" class="mb-2" style="width: 48px; height: 48px; color: #FFC107;"></i>
+                    <i data-feather="log-in" class="mb-2 icon-48 text-yellow"></i>
                     <h3 class="text-white">Sign In</h3>
                     <p class="text-white-80">Welcome back to AI Classroom</p>
                 </div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -4,10 +4,10 @@
 
 {% block content %}
 <div class="d-flex justify-content-center align-items-center min-vh-100 bg-primary">
-    <div class="card shadow-lg border-0 bg-white rounded-4" style="width: 100%; max-width: 500px;">
+    <div class="card shadow-lg border-0 bg-white rounded-4 w-100 maxw-500">
         <div class="card-body px-4 py-5">
             <div class="text-center mb-4">
-                <i data-feather="user-plus" class="text-primary mb-3" style="width: 48px; height: 48px;"></i>
+                <i data-feather="user-plus" class="text-primary mb-3 icon-48"></i>
                 <h3 class="fw-bold">Create Account</h3>
                 <p class="text-muted">Join AI Classroom today</p>
             </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,152 +20,21 @@
     
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
     
     <!-- Custom Color Scheme -->
-    <style>
-        /* Override Bootstrap with your beautiful color scheme */
-        .card.gradient-blue {
-            background: linear-gradient(135deg, #219CF3, #1976D2) !important;
-            color: white !important;
-        }
-        .card.gradient-teal {
-            background: linear-gradient(135deg, #00BCD4, #4DD0E1) !important;
-        }
-        .card.gradient-coral {
-            background: linear-gradient(135deg, #FF8A65, #EF5350) !important;
-            color: white !important;
-        }
-        .btn.btn-gradient-blue {
-            background: linear-gradient(135deg, #219CF3, #1976D2) !important;
-            color: white !important;
-            border: none !important;
-        }
-        .btn.btn-gradient-teal {
-            background-color: #00BCD4 !important;
-            color: white !important;
-            border: none !important;
-        }
-        .btn.btn-yellow {
-            background-color: #FFC107 !important;
-            color: #1976D2 !important;
-            border: none !important;
-            font-weight: bold !important;
-        }
-        .badge.badge-coral {
-            background-color: #EF5350 !important;
-            color: white !important;
-        }
-        .text-white-80 {
-            color: rgba(255,255,255,0.8) !important;
-        }
-        .text-white-90 {
-            color: rgba(255,255,255,0.9) !important;
-        }
-        .text-yellow {
-            color: #FFC107 !important;
-        }
-    </style>
-    
-    <style>
-        /* Custom styles from classroom.html */
-        .gradient-blue {
-            background: linear-gradient(to bottom right, #1976D2, #2196F3) !important;
-        }
-        .card {
-            box-shadow: 0px 2px 6px rgba(0,0,0,0.15);
-        }
-        .rounded-4 {
-            border-radius: 1rem;
-        }
-        .text-white-80 {
-            color: rgba(255, 255, 255, 0.8) !important;
-        }
-        .text-light-muted {
-            color: #E0E0E0 !important;
-        }
-        .badge-material {
-            background-color: #FFC107 !important;
-            color: #000 !important;
-            font-weight: 600 !important;
-            font-size: 0.75rem !important;
-            padding: 4px 8px !important;
-            border-radius: 0.5rem !important;
-        }
-        .badge-invite {
-            background-color: #F06292 !important;
-            color: #fff !important;
-            font-weight: 600 !important;
-            font-size: 0.75rem !important;
-            padding: 4px 8px !important;
-            border-radius: 0.5rem !important;
-        }
-        .modal-content.gradient-blue {
-            background: linear-gradient(to bottom right, #1976D2, #2196F3) !important;
-            color: white !important;
-        }
-        .modal-content.gradient-blue .form-label,
-        .modal-content.gradient-blue .form-text {
-            color: rgba(255, 255, 255, 0.8) !important;
-        }
-        .modal-content.gradient-blue input[type="text"],
-        .modal-content.gradient-blue input[type="file"],
-        .modal-content.gradient-blue input[type="email"] {
-            background-color: rgba(255, 255, 255, 0.1) !important;
-            border: 1px solid rgba(255, 255, 255, 0.4) !important;
-            color: white !important;
-        }
-        .modal-content.gradient-blue input::placeholder {
-            color: rgba(255, 255, 255, 0.6) !important;
-        }
-        .gradient-purple {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
-        }
-        .gradient-light-blue {
-            background: linear-gradient(135deg, #64B5F6, #42A5F5) !important;
-            color: white !important;
-        }
-    </style>
-    
-    <style>
-        /* Custom hover style for AI Tools button */
-        .list-group-item .dropdown .btn.btn-outline-light:hover {
-            color: #1976D2 !important; /* Dark blue for visibility on hover */
-        }
-    </style>
-    
-    <style>
-        /* Ensure Quiz History table text is dark */
-        .card.gradient-teal table, 
-        .card.gradient-teal th, 
-        .card.gradient-teal td {
-            color: #333 !important; /* Dark grey for visibility */
-        }
-    </style>
-    
-    <style>
-        /* Custom styles for delete/remove buttons on classroom page */
-        .list-group-item .btn-outline-danger {
-            background-color: #dc3545 !important; /* Bootstrap red */
-            color: white !important;
-            border-color: #dc3545 !important;
-        }
-
-        .list-group-item .btn-outline-danger:hover,
-        .list-group-item .btn-outline-danger:focus,
-        .list-group-item .btn-outline-danger:active {
-            background-color: transparent !important;
-            color: #dc3545 !important;
-            border-color: #dc3545 !important;
-        }
-    </style>
-    
+        
+        
+        
+        
+        
     <!-- htmx -->
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     
     <!-- Feather Icons -->
     <script src="https://unpkg.com/feather-icons"></script>
 </head>
-<body class="d-flex flex-column min-vh-100" style="background-color: #0b4e91;">
+<body class="d-flex flex-column min-vh-100 bg-dark-blue">
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
@@ -251,7 +120,7 @@
     <main class="container my-4 flex-grow-1">
         {% if error_message %}
             <div class="text-center py-5">
-                <i data-feather="alert-circle" class="text-warning" style="width: 64px; height: 64px;"></i>
+                <i data-feather="alert-circle" class="text-warning icon-64"></i>
                 <h2 class="mt-3">{{ error_message }}</h2>
                 <a href="{{ url_for('index') }}" class="btn btn-primary mt-3">
                     <i data-feather="home" class="me-2"></i>Go Home
@@ -333,22 +202,7 @@
     </script>
 
     <!-- Loading Overlay -->
-    <div id="loadingOverlay" style="
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.7);
-        color: white;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        z-index: 9999;
-        opacity: 0;
-        visibility: hidden;
-        transition: opacity 0.3s ease;
-    ">
+    <div id="loadingOverlay" class="loading-overlay">
         <div class="text-center">
             <div class="spinner-border text-light" role="status">
                 <span class="visually-hidden">Loading...</span>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,44 +3,13 @@
 {% block title %}Welcome - AI Enhanced Classroom{% endblock %}
 
 {% block content %}
-<style>
-    .bg-gradient-blue {
-        background: linear-gradient(135deg, #2196F3, #1976D2);
-    }
-    .bg-gradient-cyan {
-        background: linear-gradient(135deg, #03A9F4, #039BE5);
-    }
-    .bg-gradient-red {
-        background: linear-gradient(135deg, #FF8A65, #EF5350);
-    }
-    .btn-hero {
-        font-weight: 600;
-        border: none;
-    }
-    .btn-hero-start {
-        background: linear-gradient(135deg, #2196F3, #1976D2);
-        color: #fff;
-    }
-    .btn-hero-start:hover {
-        background: linear-gradient(135deg, #1976D2, #2196F3);
-        color: #fff;
-    }
-    .btn-hero-signin {
-        background-color: #00BCD4;
-        color: #fff;
-    }
-    .btn-hero-signin:hover {
-        background-color: #0097A7;
-        color: #fff;
-    }
-</style>
 
 <div class="row justify-content-center">
     <div class="col-lg-8">
         <!-- Hero Section -->
         <div class="text-center py-5">
             <div class="mb-4">
-                <i data-feather="book-open" style="width: 80px; height: 80px; color: #2196F3;"></i>
+                <i data-feather="book-open" class="icon-80 text-primary"></i>
             </div>
             <h1 class="display-4 mb-3 text-white">AI Enhanced Classroom</h1>
             <p class="lead text-white-80 mb-4">
@@ -63,7 +32,7 @@
             <div class="col-md-4">
                 <div class="card h-100 border-0 bg-gradient-blue text-white">
                     <div class="card-body text-center">
-                        <i data-feather="users" class="mb-3" style="width: 48px; height: 48px; color: #FFC107;"></i>
+                        <i data-feather="users" class="mb-3 icon-48 text-yellow"></i>
                         <h5 class="card-title">For Teachers</h5>
                         <p class="card-text text-white-80">
                             Create classrooms, manage students, upload materials, and track learning progress with detailed analytics.
@@ -74,7 +43,7 @@
             <div class="col-md-4">
                 <div class="card h-100 border-0 bg-gradient-cyan text-white">
                     <div class="card-body text-center">
-                        <i data-feather="zap" class="mb-3" style="width: 48px; height: 48px; color: #FFC107;"></i>
+                        <i data-feather="zap" class="mb-3 icon-48 text-yellow"></i>
                         <h5 class="card-title">AI-Powered Learning</h5>
                         <p class="card-text text-white-80">
                             Generate personalized study guides and self-evaluation quizzes using Google's Gemini AI technology.
@@ -85,7 +54,7 @@
             <div class="col-md-4">
                 <div class="card h-100 border-0 bg-gradient-red text-white">
                     <div class="card-body text-center">
-                        <i data-feather="smartphone" class="mb-3" style="width: 48px; height: 48px; color: #FFC107;"></i>
+                        <i data-feather="smartphone" class="mb-3 icon-48 text-yellow"></i>
                         <h5 class="card-title">Mobile Ready</h5>
                         <p class="card-text text-white-80">
                             Progressive Web App (PWA) design works seamlessly on all devices with offline support.
@@ -109,7 +78,7 @@
                 <div class="col-md-6">
                     <div class="d-flex">
                         <div class="flex-shrink-0">
-                            <div class="bg-primary rounded-circle d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;">
+                            <div class="bg-primary rounded-circle d-flex align-items-center justify-content-center" class="icon-40">
                                 <span class="text-white fw-bold">{{ loop.index }}</span>
                             </div>
                         </div>

--- a/templates/student/all_activities.html
+++ b/templates/student/all_activities.html
@@ -34,7 +34,7 @@
         {% if evaluations %}
             <div class="list-group list-group-flush">
                 {% for evaluation in evaluations %}
-                    <div class="list-group-item border-secondary d-flex justify-content-between align-items-center text-white" style="background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px;">
+                    <div class="list-group-item border-secondary d-flex justify-content-between align-items-center text-white list-bg-dark">
                         <div class="flex-grow-1">
                             {% if evaluation.is_ai_generated %}
                                 <h6 class="mb-1 text-white">
@@ -56,11 +56,11 @@
                         </div>
                         <div class="text-end">
                             {% if evaluation.score is not none %}
-                                <span class="badge text-yellow fw-bold" style="background-color: rgba(255,255,255,0.2);">
+                                <span class="badge text-yellow fw-bold bg-white-20">
                                     {{ "%.0f"|format(evaluation.score) }}%
                                 </span>
                             {% else %}
-                                <span class="badge text-white" style="background-color: #FF8A65;">In Progress</span>
+                                <span class="badge text-white badge-coral-bg">In Progress</span>
                             {% endif %}
                             {% if evaluation.completed_at %}
                                 <small class="text-white-80 d-block mt-1">
@@ -85,7 +85,7 @@
             </div>
         {% else %}
             <div class="text-center py-4 text-white">
-                <i data-feather="activity" class="text-white-50 mb-3" style="width: 48px; height: 48px;"></i>
+                <i data-feather="activity" class="text-white-50 mb-3 icon-48"></i>
                 <h6 class="text-white">No activities yet</h6>
                 <p class="text-white-80">Start learning with AI-generated study guides and quizzes!</p>
             </div>

--- a/templates/student/classroom.html
+++ b/templates/student/classroom.html
@@ -32,7 +32,7 @@
                 {% if materials %}
                     <div class="list-group list-group-flush">
                         {% for material in materials %}
-                            <div class="list-group-item border-secondary d-flex justify-content-between align-items-start text-white" style="background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px;">
+                            <div class="list-group-item border-secondary d-flex justify-content-between align-items-start text-white list-bg-dark">
                                 <div class="flex-grow-1">
                                     <h6 class="mb-1 text-white">{{ material.title }}</h6>
                                     <small class="text-white-80">
@@ -82,7 +82,7 @@
                     </div>
                 {% else %}
                     <div class="text-center py-4 text-white">
-                        <i data-feather="file-text" class="text-white-50 mb-3" style="width: 48px; height: 48px;"></i>
+                        <i data-feather="file-text" class="text-white-50 mb-3 icon-48"></i>
                         <h6 class="text-white">No materials available yet</h6>
                         <p class="text-white-80">Your teacher hasn't uploaded any materials for this class.</p>
                     </div>
@@ -254,7 +254,7 @@
                                 {% for material_id, student_avg in student_ai_performance_by_material.items() %}
                                     {% set class_avg = class_ai_performance_by_material.get(material_id) %}
                                     {% if student_avg is not none or class_avg is not none %}
-                                        <li class="list-group-item border-secondary text-white" style="background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px;">
+                                        <li class="list-group-item border-secondary text-white list-bg-dark">
                                             <h6 class="mb-1 text-white">{{ material_titles.get(material_id, 'Unknown Material') }}</h6>
                                             <div class="row small">
                                                 <div class="col-md-6">
@@ -291,7 +291,7 @@
                                     {% if material_id not in student_ai_performance_by_material %}
                                         {% set student_avg = student_ai_performance_by_material.get(material_id) %}
                                         {% if class_avg is not none %}
-                                             <li class="list-group-item border-secondary text-white" style="background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px;">
+                                             <li class="list-group-item border-secondary text-white list-bg-dark">
                                                 <h6 class="mb-1 text-white">{{ material_titles.get(material_id, 'Unknown Material') }}</h6>
                                                 <div class="row small">
                                                     <div class="col-md-6">
@@ -328,7 +328,7 @@
                 <div class="card-body">
                     <ul class="list-group list-group-flush">
                         {% for evaluation in recent_evaluations %}
-                            <li class="list-group-item border-secondary d-flex justify-content-between align-items-start text-white" style="background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px;">
+                            <li class="list-group-item border-secondary d-flex justify-content-between align-items-start text-white list-bg-dark">
                                 <div class="flex-grow-1">
                                     <h6 class="mb-1 text-white">
                                         {% if evaluation.is_ai_generated %}
@@ -385,7 +385,7 @@
                 </div>
                  <div class="card-body">
                     <div class="text-center py-4 text-white">
-                        <i data-feather="activity" class="text-white-50 mb-3" style="width: 48px; height: 48px;"></i>
+                        <i data-feather="activity" class="text-white-50 mb-3 icon-48"></i>
                         <h6 class="text-white">No recent activity yet</h6>
                         <p class="text-white-80">Complete a quiz or other activity to see it here.</p>
                     </div>

--- a/templates/student/dashboard.html
+++ b/templates/student/dashboard.html
@@ -126,7 +126,7 @@
     </div>
 {% else %}
     <div class="text-center py-5">
-        <i data-feather="book-plus" class="text-white-50 mb-3" style="width: 64px; height: 64px;"></i>
+        <i data-feather="book-plus" class="text-white-50 mb-3" class="text-white-50 mb-3 icon-64"></i>
         <h3 class="text-white">No Classrooms Yet</h3>
         <p class="text-white-80">Join your first classroom using an invitation code from your teacher.</p>
         <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#joinClassroomModal">
@@ -148,7 +148,7 @@
                 <h6 class="text-white-80 mb-3">{{ classroom_names.get(classroom_id, 'Unknown Classroom') }}</h6>
                 <ul class="list-group list-group-flush mb-4">
                     {% for material_id, award_info in awards_by_material.items() %}
-                        <li class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center" style="background: rgba(0,0,0,0.3); border-radius: 8px;">
+                        <li class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center" class="list-bg-dark">
                             <div>
                                 <h6 class="mb-1 text-white">{{ award_info.material_title }}</h6>
                                 <small class="text-white-80">
@@ -157,11 +157,11 @@
                             </div>
                             <div>
                                 {% if award_info.award == 'gold' %}
-                                    <i class="fas fa-medal text-warning" style="font-size: 1.5rem;" title="Gold Award"></i> {# Gold medal icon #}
+                                    <i class="fas fa-medal text-warning" class="icon-medal" title="Gold Award"></i> {# Gold medal icon #}
                                 {% elif award_info.award == 'silver' %}
-                                    <i class="fas fa-medal text-secondary" style="font-size: 1.5rem;" title="Silver Award"></i> {# Silver medal icon #}
+                                    <i class="fas fa-medal text-secondary" class="icon-medal" title="Silver Award"></i> {# Silver medal icon #}
                                 {% elif award_info.award == 'bronze' %}
-                                    <i class="fas fa-medal text-danger" style="font-size: 1.5rem;" title="Bronze Award"></i> {# Bronze medal icon #}
+                                    <i class="fas fa-medal text-danger" class="icon-medal" title="Bronze Award"></i> {# Bronze medal icon #}
                                 {% endif %}
                             </div>
                         </li>

--- a/templates/student/study_guide.html
+++ b/templates/student/study_guide.html
@@ -54,7 +54,7 @@
     <div class="col-md-4">
         <div class="card border-0 gradient-blue h-100">
             <div class="card-body text-center">
-                <i data-feather="help-circle" class="text-white mb-3" style="width: 48px; height: 48px;"></i>
+                <i data-feather="help-circle" class="text-white mb-3 icon-48"></i>
                 <h6 class="text-white">Multiple Choice Quiz</h6>
                 <p class="text-white-80 small">Test your understanding with AI-generated multiple choice questions.</p>
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq', material_id=material_id) }}" 
@@ -65,7 +65,7 @@
     <div class="col-md-4">
         <div class="card border-0 gradient-blue h-100">
             <div class="card-body text-center">
-                <i data-feather="check-circle" class="text-white mb-3" style="width: 48px; height: 48px;"></i>
+                <i data-feather="check-circle" class="text-white mb-3 icon-48"></i>
                 <h6 class="text-white">True/False Quiz</h6>
                 <p class="text-white-80 small">Quick assessment with true or false questions.</p>
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='true_false', material_id=material_id) }}" 
@@ -76,7 +76,7 @@
     <div class="col-md-4">
         <div class="card border-0 gradient-blue h-100">
             <div class="card-body text-center">
-                <i data-feather="edit-3" class="text-white mb-3" style="width: 48px; height: 48px;"></i>
+                <i data-feather="edit-3" class="text-white mb-3 icon-48"></i>
                 <h6 class="text-white">Essay Questions</h6>
                 <p class="text-white-80 small">Practice writing detailed responses to essay questions.</p>
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='essay', material_id=material_id) }}" 
@@ -86,35 +86,4 @@
     </div>
 </div>
 
-<style>
-@media print {
-    .navbar, .card-header, .card-footer, .btn, .row.mt-4 {
-        display: none !important;
-    }
-    
-    .card {
-        border: none !important;
-        background: white !important;
-        color: black !important;
-    }
-    
-    .study-guide-content {
-        color: black !important;
-    }
-    
-    .text-primary, .text-info, .text-warning, .text-white, .text-white-80, .text-white-50, .text-yellow {
-        color: black !important;
-    }
-    
-    .badge {
-        color: black !important;
-        background-color: #eee !important;
-    }
-    
-    /* Ensure icons are black in print */
-    .study-guide-content i[data-feather] {
-        color: black !important;
-    }
-}
-</style>
 {% endblock %}

--- a/templates/teacher/classroom.html
+++ b/templates/teacher/classroom.html
@@ -41,7 +41,7 @@
                 {% if materials %}
                     <div class="list-group list-group-flush">
                         {% for material in materials %}
-                            <div class="list-group-item border-secondary d-flex justify-content-between align-items-center text-white" style="background-color: rgba(0,0,0,0.3);">
+                            <div class="list-group-item border-secondary d-flex justify-content-between align-items-center text-white">
                                 <div>
                                     <h6 class="mb-1 text-white">{{ material.title }}</h6>
                                     <small class="text-white-80">
@@ -71,7 +71,7 @@
                     </div>
                 {% else %}
                     <div class="text-center py-4 text-white">
-                        <i data-feather="file-plus" class="text-white-50 mb-3" style="width: 48px; height: 48px;"></i>
+                        <i data-feather="file-plus" class="text-white-50 mb-3 icon-48"></i>
                         <h6 class="text-white">No materials uploaded yet</h6>
                         <p class="text-white-80">Upload PDF or text files for your students to access.</p>
                     </div>
@@ -100,7 +100,7 @@
                 {% if quizzes %}
                     <div class="list-group list-group-flush">
                         {% for quiz in quizzes %}
-                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center" style="background-color: rgba(0,0,0,0.3);">
+                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center">
                                 <div>
                                     <h6 class="mb-0 text-white">{{ quiz.title }}</h6>
                                     <small class="text-white-80">{{ quiz.quiz_type.title() }}</small>
@@ -113,7 +113,7 @@
                     </div>
                 {% else %}
                     <div class="text-center py-4 text-white">
-                        <i data-feather="clipboard" class="text-white-50 mb-3" style="width: 48px; height: 48px;"></i>
+                        <i data-feather="clipboard" class="text-white-50 mb-3 icon-48"></i>
                         <h6 class="text-white">No quizzes created yet</h6>
                         <p class="text-white-80">Create quizzes for this classroom from the Quizzes page.</p>
                     </div>
@@ -137,7 +137,7 @@
                 {% if students %}
                     <div class="list-group list-group-flush">
                         {% for student in students %}
-                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center" style="background-color: rgba(0,0,0,0.3);">
+                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center">
                                 <div class="d-flex align-items-center">
                                     <i data-feather="user" class="me-2 text-white-50"></i>
                                     <div>
@@ -164,7 +164,7 @@
                     </div>
                 {% else %}
                     <div class="text-center py-4 text-white">
-                        <i data-feather="user-plus" class="text-white-50 mb-3" style="width: 48px; height: 48px;"></i>
+                        <i data-feather="user-plus" class="text-white-50 mb-3 icon-48"></i>
                         <h6 class="text-white">No students enrolled</h6>
                         <p class="text-white-80">Add students by email or share the invitation code.</p>
                     </div>

--- a/templates/teacher/dashboard.html
+++ b/templates/teacher/dashboard.html
@@ -36,7 +36,7 @@
                         <div class="mb-3">
                             <small class="text-white-80">
                                 <strong>Invitation Code:</strong> 
-                                <code style="background-color: rgba(255,255,255,0.2); padding: 2px 8px; border-radius: 4px;" class="text-yellow">{{ classroom.invitation_code }}</code>
+                                <code class="text-yellow code-inline">{{ classroom.invitation_code }}</code>
                             </small>
                         </div>
                         
@@ -47,7 +47,7 @@
                             <a href="{{ url_for('teacher_quizzes', classroom_id=classroom.id) }}" class="btn btn-sm btn-yellow">
                                 <i data-feather="help-circle" class="me-1"></i>Quizzes
                             </a>
-                            <a href="{{ url_for('teacher_results', classroom_id=classroom.id) }}" class="btn btn-sm" style="background-color: rgba(255,255,255,0.2); color: white; border: 1px solid rgba(255,255,255,0.3);">
+                            <a href="{{ url_for('teacher_results', classroom_id=classroom.id) }}" class="btn btn-sm btn-results">
                                 <i data-feather="bar-chart-2" class="me-1"></i>Results
                             </a>
                         </div>
@@ -70,7 +70,7 @@
     </div>
 {% else %}
     <div class="text-center py-5">
-        <i data-feather="folder-plus" class="text-white-50 mb-3" style="width: 64px; height: 64px;"></i>
+        <i data-feather="folder-plus" class="text-white-50 mb-3 icon-64"></i>
         <h3 class="text-white">No Classrooms Yet</h3>
         <p class="text-white-80">Create your first classroom to start managing students and materials.</p>
         <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createClassroomModal">

--- a/templates/teacher/quizzes.html
+++ b/templates/teacher/quizzes.html
@@ -3,55 +3,6 @@
 {% block title %}Quizzes - {{ classroom.name }}{% endblock %}
 
 {% block content %}
-<style>
-    /* Temporary styles to force badge rendering */
-    .badge {
-        display: inline-block;
-        padding: 0.35em 0.65em;
-        font-size: 0.75em;
-        font-weight: 700;
-        line-height: 1;
-        text-align: center;
-        white-space: nowrap;
-        vertical-align: baseline;
-        border-radius: 0.25rem;
-        /* Ensure text is visible */
-        color: #fff !important; /* Default to white text */
-    }
-
-    .badge.badge-primary {
-        background-color: #0d6efd !important;
-    }
-    .badge.badge-secondary {
-        background-color: #17d083 !important;
-        color: #000 !important; /* Dark text for secondary */
-    }
-    .badge.badge-success {
-        background-color: #198754 !important;
-    }
-    .badge.badge-danger {
-        background-color: #dc3545 !important;
-    }
-    .badge.badge-warning {
-        background-color: #ffc107 !important;
-        color: #000 !important; /* Dark text for warning */
-    }
-    .badge.badge-info {
-        background-color: #0dcaf0 !important;
-        color: #000 !important; /* Dark text for info */
-    }
-    .badge.badge-light {
-         background-color: #f8f9fa !important;
-         color: #000 !important; /* Dark text for light */
-    }
-    .badge.badge-dark {
-        background-color: #212529 !important;
-    }
-     .badge.badge-coral {
-        background-color: #EF5350 !important; /* Using the color defined in your custom styles */
-        color: white !important;
-    }
-</style>
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2 class="text-white">Quizzes for {{ classroom.name }}</h2>

--- a/templates/teacher/results.html
+++ b/templates/teacher/results.html
@@ -34,23 +34,23 @@
                                     <h4 class="text-warning">
                                         {{ "%.1f"|format(student_summary.avg_score) }}%
                                     </h4>
-                                    <div class="progress" style="height: 5px;">
-                                        <div class="progress-bar" style="background-color: #FFC107; width: {{ student_summary.avg_score | default(0) }}%;"></div>
+                                    <div class="progress progress-thin">
+                                        <div class="progress-bar progress-bar-yellow" style="width: {{ student_summary.avg_score | default(0) }}%;"></div>
                                     </div>
                                 </div>
                             {% endif %}
 
                             <div class="row text-center mb-3">
                                 <div class="col-4">
-                                    <div class="fw-bold" style="color: #00BCD4;">{{ student_summary.completed_count }}</div>
+                                    <div class="fw-bold text-cyan">{{ student_summary.completed_count }}</div>
                                     <small class="text-white">Completed</small>
                                 </div>
                                 <div class="col-4">
-                                    <div class="fw-bold" style="color: #FF8A65;">{{ student_summary.in_progress_count }}</div>
+                                    <div class="fw-bold text-coral">{{ student_summary.in_progress_count }}</div>
                                     <small class="text-white">In Progress</small>
                                 </div>
                                 <div class="col-4">
-                                    <div class="fw-bold" style="color: #64B5F6;">{{ student_summary.materials_attempted }}</div>
+                                    <div class="fw-bold text-light-blue">{{ student_summary.materials_attempted }}</div>
                                     <small class="text-white">Materials</small>
                                 </div>
                             </div>
@@ -190,7 +190,7 @@
     </div>
 {% else %}
     <div class="text-center py-5">
-        <i data-feather="bar-chart-2" class="text-white-50 mb-3" style="width: 64px; height: 64px;"></i>
+        <i data-feather="bar-chart-2" class="text-white-50 mb-3 icon-64"></i>
         <h3 class="text-white">No Results Yet</h3>
         <p class="text-white-80">Students haven't completed any self-evaluations yet.</p>
         <a href="{{ url_for('teacher_classroom', classroom_id=classroom.id) }}" class="btn btn-primary">

--- a/templates/teacher/student_details.html
+++ b/templates/teacher/student_details.html
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="col-md-3">
-        <div class="card border-0 text-center" style="background: linear-gradient(135deg, #64B5F6, #42A5F5); color: white;">
+        <div class="card border-0 text-center gradient-light-blue text-white">
             <div class="card-body">
                 <h3 class="text-white">{{ materials_performance|length }}</h3>
                 <p class="text-white-80 mb-0">Materials Attempted</p>
@@ -67,7 +67,7 @@
             <div class="row">
                 {% for material_key, material_data in materials_performance.items() %}
                     <div class="col-lg-6 mb-4">
-                        <div class="card h-100" style="background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2);">
+                        <div class="card h-100 bg-white-10-border">
                             <div class="card-body">
                                 <h6 class="card-title text-white">{{ material_data.material_title }}</h6>
                                 
@@ -81,9 +81,9 @@
                                             {{ "%.1f"|format(material_avg) }}%
                                         </span>
                                     </div>
-                                    <div class="progress" style="height: 6px; background-color: rgba(255,255,255,0.2);">
+                                    <div class="progress progress-thin-6">
                                         <div class="progress-bar" 
-                                            style="background-color: #FFC107; width: {{ material_avg }}%"></div>
+                                            class="progress-bar-yellow" style="width: {{ material_avg }}%"></div>
                                     </div>
                                 </div>
                                 
@@ -130,7 +130,7 @@
                     </thead>
                     <tbody>
                         {% for evaluation in evaluations %}
-                            <tr style="border-bottom: 1px solid rgba(0,0,0,0.1); background-color: rgba(255,255,255,0.9); color: #333;">
+                            <tr class="row-light">
                                 <td>
                                     <h6 class="mb-0">
                                         {% if evaluation.quiz %}
@@ -143,17 +143,17 @@
                                         {% endif %}
                                     </h6>
                                     {% if evaluation.is_ai_generated %}
-                                        <small class="text-muted"><i data-feather="zap" class="me-1 text-muted" style="width: 14px; height: 14px;"></i>AI-Generated</small>
+                                        <small class="text-muted"><i data-feather="zap" class="me-1 text-muted icon-14"></i>AI-Generated</small>
                                     {% else %}
-                                        <small class="text-muted"><i data-feather="edit-3" class="me-1 text-muted" style="width: 14px; height: 14px;"></i>Teacher-Created</small>
+                                        <small class="text-muted"><i data-feather="edit-3" class="me-1 text-muted icon-14"></i>Teacher-Created</small>
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if evaluation.score is not none %}
                                         <div class="d-flex align-items-center">
-                                            <div class="progress me-2" style="width: 50px; background-color: rgba(0,0,0,0.1); height: 8px;">
+                                            <div class="progress me-2 progress-small-container">
                                                 <div class="progress-bar" 
-                                                    style="background-color: #FFC107; width: {{ evaluation.score }}%"></div>
+                                                    class="progress-bar-yellow" style="width: {{ evaluation.score }}%"></div>
                                             </div>
                                             <span class="text-yellow fw-bold">
                                                 {{ "%.1f"|format(evaluation.score) }}%
@@ -172,9 +172,9 @@
                                 </td>
                                 <td>
                                     {% if evaluation.completed_at %}
-                                        <span class="badge" style="background-color: #00BCD4; color: white;">Completed</span>
+                                        <span class="badge badge-cyan">Completed</span>
                                     {% else %}
-                                        <span class="badge" style="background-color: #FF8A65; color: white;">In Progress</span>
+                                        <span class="badge badge-coral-bg">In Progress</span>
                                     {% endif %}
                                 </td>
                             </tr>
@@ -186,7 +186,7 @@
     </div>
 {% else %}
     <div class="text-center py-5">
-        <i data-feather="clipboard" class="text-muted mb-3" style="width: 64px; height: 64px;"></i>
+        <i data-feather="clipboard" class="text-muted mb-3 icon-64"></i>
         <h3 class="text-muted">No Quiz Activity</h3>
         <p class="text-muted">This student hasn't taken any quizzes yet.</p>
     </div>

--- a/templates/teacher/view_submission.html
+++ b/templates/teacher/view_submission.html
@@ -59,7 +59,7 @@
                     {% endif %}
                     
                     {% if feedback_item and feedback_item.explanation %}
-                        <div class="p-3 mt-2 rounded" style="background-color: rgba(255, 255, 255, 0.1); color: #f8f9fa;">
+                        <div class="p-3 mt-2 rounded" class="bg-white-10 text-light">
                             <strong>Explanation:</strong> {{ feedback_item.explanation }}
                         </div>
                     {% endif %}


### PR DESCRIPTION
## Summary
- centralize all template styling into `static/css/styles.css`
- link global stylesheet in `base.html`
- replace many inline styles with reusable CSS classes
- remove old `<style>` blocks for cleaner templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844522e47948326b80971cec02f08a4