### PR TITLE
Fix list-group flush rounding

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -175,6 +175,9 @@
 
 .bg-dark-blue { background-color: #0b4e91; }
 .list-bg-dark { background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px; }
+.list-group-flush > .list-bg-dark {
+    border-radius: 8px;
+}
 .bg-white-10 { background-color: rgba(255,255,255,0.1); }
 .bg-white-10-border { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); }
 .text-cyan { color: #00BCD4 !important; }


### PR DESCRIPTION
## Summary
- maintain rounded corners on dark list items inside `list-group-flush`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e1867a108326880d6358ed32a894