### PR TITLE
Apply dark background to teacher classroom lists

### DIFF
--- a/templates/teacher/classroom.html
+++ b/templates/teacher/classroom.html
@@ -41,7 +41,7 @@
                 {% if materials %}
                     <div class="list-group list-group-flush">
                         {% for material in materials %}
-                            <div class="list-group-item border-secondary d-flex justify-content-between align-items-center text-white">
+                            <div class="list-group-item border-secondary d-flex justify-content-between align-items-center text-white list-bg-dark">
                                 <div>
                                     <h6 class="mb-1 text-white">{{ material.title }}</h6>
                                     <small class="text-white-80">
@@ -100,7 +100,7 @@
                 {% if quizzes %}
                     <div class="list-group list-group-flush">
                         {% for quiz in quizzes %}
-                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center">
+                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center list-bg-dark">
                                 <div>
                                     <h6 class="mb-0 text-white">{{ quiz.title }}</h6>
                                     <small class="text-white-80">{{ quiz.quiz_type.title() }}</small>
@@ -137,7 +137,7 @@
                 {% if students %}
                     <div class="list-group list-group-flush">
                         {% for student in students %}
-                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center">
+                            <div class="list-group-item border-secondary text-white d-flex justify-content-between align-items-center list-bg-dark">
                                 <div class="d-flex align-items-center">
                                     <i data-feather="user" class="me-2 text-white-50"></i>
                                     <div>


### PR DESCRIPTION
## Summary
- tweak teacher classroom list-group items to use dark background

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `grep -n -E '<[^>]+class="[^"]+"[^>]*class="' -R templates`

------
https://chatgpt.com/codex/tasks/task_e_6844e36a78848326ac47d1398cce30a1