### PR TITLE
Expand AI quiz generation

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -50,7 +50,7 @@ class AIService:
         
         if quiz_type == "mcq":
             prompt = f"""
-            Create 5 multiple choice questions based on the provided course material.
+            Create 20 higher-order thinking multiple choice questions based on the provided course material.
 
             MATERIAL CONTENT:
             {content}
@@ -69,12 +69,12 @@ class AIService:
                 }}
             ]
 
-            Generate exactly 5 questions based on the material above. Return ONLY the JSON array.
+            Generate exactly 20 questions that require analysis, evaluation or application. Return ONLY the JSON array.
             """
         
         elif quiz_type == "true_false":
             prompt = f"""
-            Create 5 true/false questions based on the provided course material.
+            Create 20 higher-order thinking true/false questions based on the provided course material.
 
             MATERIAL CONTENT:
             {content}
@@ -92,7 +92,7 @@ class AIService:
                 }}
             ]
 
-            Generate exactly 5 true/false questions based on the material above. Return ONLY the JSON array.
+            Generate exactly 20 true/false questions that require analysis, evaluation or application. Return ONLY the JSON array.
             """
         
         elif quiz_type == "essay":


### PR DESCRIPTION
## Summary
- adjust AI prompts to create 20 higher-order thinking MCQ and true/false questions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845378d145083269d3db6bc3cfd0052