### PR TITLE
Add teacher profile update pages

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1774,6 +1774,58 @@ def teacher_reset_student_password(classroom_id, student_id):
 
     return redirect(url_for('teacher_classroom', classroom_id=classroom_id))
 
+@app.route('/teacher/edit_profile', methods=['GET', 'POST'])
+@login_required
+def teacher_edit_profile():
+    if current_user.role != 'teacher':
+        flash('Access denied', 'error')
+        return redirect(url_for('index'))
+
+    if request.method == 'POST':
+        current_user.first_name = request.form.get('first_name')
+        current_user.last_name = request.form.get('last_name')
+
+        try:
+            db.session.commit()
+            flash('Profile updated successfully!', 'success')
+            return redirect(url_for('teacher_dashboard'))
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error updating profile: {str(e)}', 'error')
+
+    return render_template('teacher/edit_profile.html', teacher=current_user)
+
+@app.route('/teacher/change_password', methods=['GET', 'POST'])
+@login_required
+def teacher_change_password():
+    if current_user.role != 'teacher':
+        flash('Access denied', 'error')
+        return redirect(url_for('index'))
+
+    if request.method == 'POST':
+        current_password = request.form.get('current_password')
+        new_password = request.form.get('new_password')
+        confirm_password = request.form.get('confirm_password')
+
+        if not current_user.check_password(current_password):
+            flash('Incorrect current password', 'error')
+            return render_template('teacher/change_password.html')
+
+        if new_password != confirm_password:
+            flash('New passwords do not match', 'error')
+            return render_template('teacher/change_password.html')
+
+        current_user.set_password(new_password)
+        try:
+            db.session.commit()
+            flash('Password changed successfully!', 'success')
+            return redirect(url_for('teacher_dashboard'))
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error changing password: {str(e)}', 'error')
+
+    return render_template('teacher/change_password.html')
+
 @app.route('/student/edit_profile', methods=['GET', 'POST'])
 @login_required
 def student_edit_profile():

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,6 +68,12 @@
                                     <li><a class="dropdown-item" href="{{ url_for('teacher_dashboard') }}">
                                         <i data-feather="home" class="me-2"></i>Dashboard
                                     </a></li>
+                                    <li><a class="dropdown-item" href="{{ url_for('teacher_edit_profile') }}">
+                                        <i data-feather="user" class="me-2"></i>Edit Profile
+                                    </a></li>
+                                    <li><a class="dropdown-item" href="{{ url_for('teacher_change_password') }}">
+                                        <i class="fas fa-key me-2"></i>Change Password
+                                    </a></li>
                                 {% else %}
                                     <li><a class="dropdown-item" href="{{ url_for('student_dashboard') }}">
                                         <i data-feather="home" class="me-2"></i>Dashboard

--- a/templates/teacher/change_password.html
+++ b/templates/teacher/change_password.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block title %}Change Password{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card border-0 rounded-4 gradient-blue">
+                <div class="card-header bg-transparent">
+                    <h5 class="mb-0 text-white">
+                        <i class="fas fa-key me-2 text-white"></i>Change Password
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST" action="{{ url_for('teacher_change_password') }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <div class="mb-3">
+                            <label for="current_password" class="form-label text-white-80">Current Password</label>
+                            <input type="password" class="form-control" id="current_password" name="current_password" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="new_password" class="form-label text-white-80">New Password</label>
+                            <input type="password" class="form-control" id="new_password" name="new_password" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="confirm_password" class="form-label text-white-80">Confirm New Password</label>
+                            <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-yellow">
+                                <i data-feather="save" class="me-2"></i>Change Password
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    feather.replace()
+</script>
+{% endblock %}

--- a/templates/teacher/edit_profile.html
+++ b/templates/teacher/edit_profile.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% block title %}Edit Profile{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card border-0 rounded-4 gradient-blue">
+                <div class="card-header bg-transparent">
+                    <h5 class="mb-0 text-white">
+                        <i data-feather="user" class="me-2 text-white"></i>Edit Profile
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST" action="{{ url_for('teacher_edit_profile') }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <div class="mb-3">
+                            <label for="first_name" class="form-label text-white-80">First Name</label>
+                            <input type="text" class="form-control" id="first_name" name="first_name" value="{{ teacher.first_name }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="last_name" class="form-label text-white-80">Last Name</label>
+                            <input type="text" class="form-control" id="last_name" name="last_name" value="{{ teacher.last_name }}" required>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-yellow">
+                                <i data-feather="save" class="me-2"></i>Save Changes
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    feather.replace()
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow teachers to update their profile details and password
- show edit profile & change password links for teachers
- templates for teacher profile management

## Testing
- `python -m py_compile routes.py models.py app.py ai_service.py awards_utils.py simple_vector.py utils.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684538f5c0fc8326bb785e0c91bf2c9f