### PR TITLE
Daily quote context processor

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -272,3 +272,16 @@ class AIService:
         
         average_score = total_score / len(questions) if questions else 0
         return average_score, feedback
+
+    def get_daily_quote(self) -> str:
+        """Return a short CS quote or fact using Gemini"""
+        prompt = (
+            "Provide a single short inspirational quote or interesting fact about "
+            "computer science. Respond with only the quote or fact in one or two "
+            "sentences."
+        )
+        try:
+            response = self.model.generate_content(prompt)
+            return response.text.strip()
+        except Exception as e:
+            raise Exception(f"Error getting daily quote: {str(e)}")

--- a/models.py
+++ b/models.py
@@ -164,3 +164,9 @@ class Notification(db.Model):
     link = db.Column(db.String(255))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     is_read = db.Column(db.Boolean, default=False)
+
+
+class DailyQuoteCache(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date, unique=True, nullable=False)
+    quote = db.Column(db.String(255), nullable=False)

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,9 @@
                 <i data-feather="book-open" class="me-2"></i>
                 AI Classroom
             </a>
+            <div class="navbar-text flex-grow-1 mx-3 d-none d-md-block overflow-hidden" style="max-width: 300px;">
+                <marquee behavior="scroll" direction="left" scrollamount="4">{{ daily_quote }}</marquee>
+            </div>
             
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>

--- a/tests/test_quote_context.py
+++ b/tests/test_quote_context.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from app import app, db, inject_daily_quote
+
+class QuoteContextProcessorTest(unittest.TestCase):
+    def setUp(self):
+        os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["TESTING"] = True
+        with app.app_context():
+            db.create_all()
+
+    def tearDown(self):
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    @patch('app.AIService')
+    def test_inject_daily_quote_returns_quote(self, mock_service):
+        mock_service.return_value.get_daily_quote.return_value = 'CS fact'
+        with app.app_context():
+            context = inject_daily_quote()
+            self.assertIn('daily_quote', context)
+            self.assertTrue(context['daily_quote'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add AIService.get_daily_quote
- cache daily quote in new `DailyQuoteCache` model and inject into templates
- show quote as scrolling marquee in navbar
- test context processor returns quote

## Testing
- `python -m unittest discover -s tests -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68453a1032988326bd1a0ac640a5d365