### PR TITLE
Fix markdown filter sanitization

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from datetime import date
 from markupsafe import Markup # New import
 import markdown # New import
+import bleach
 # from flask_moment import Moment # Removed: Not using Flask-Moment
 
 print(f"Markdown module imported: {markdown is not None}") # Debug print
@@ -41,7 +42,9 @@ app.jinja_env.globals['chr'] = chr
 
 # Register custom markdown filter
 def markdown_filter(text):
-    return Markup(markdown.markdown(text))
+    html = markdown.markdown(text)
+    sanitized = bleach.clean(html)
+    return Markup(sanitized)
 app.jinja_env.filters['markdown'] = markdown_filter
 
 # Configure the database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "PyPDF2>=3.0.1",
     "python-docx>=1.1.2",
     "requests>=2.31.0",
+    "bleach>=6.1.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ scikit-learn
 pyPDF2
 python-docx
 requests
+bleach==6.1.0


### PR DESCRIPTION
## Summary
- sanitize markdown output in `markdown_filter`
- add Bleach dependency for sanitizing HTML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684585c402a083269f4acc51dd9363f3