### PR TITLE
Add Content Security Policy

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ load_dotenv()
 from flask import Flask
 from flask_login import LoginManager, current_user
 from flask_wtf import CSRFProtect
+# Security headers
+from flask_talisman import Talisman
 # from flask_markdown import Markdown # Removed: Using custom markdown filter
 from werkzeug.middleware.proxy_fix import ProxyFix
 from datetime import date
@@ -35,6 +37,18 @@ csrf = CSRFProtect()
 app = Flask(__name__)
 app.secret_key = os.getenv("SESSION_SECRET", "dev-secret-key")
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
+
+# Configure Content Security Policy
+csp = {
+    'default-src': ["'self'"],
+    'script-src': ["'self'", 'https://cdn.jsdelivr.net', 'https://cdnjs.cloudflare.com', 'https://unpkg.com'],
+    'style-src': ["'self'", "'unsafe-inline'", 'https://cdn.jsdelivr.net', 'https://cdnjs.cloudflare.com'],
+    'img-src': ["'self'", 'data:'],
+    'font-src': ["'self'", 'https://cdnjs.cloudflare.com'],
+    'object-src': ["'none'"]
+}
+
+Talisman(app, content_security_policy=csp)
 
 # Add chr function to Jinja2 globals
 app.jinja_env.globals['chr'] = chr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "PyPDF2>=3.0.1",
     "python-docx>=1.1.2",
     "requests>=2.31.0",
+    "Flask-Talisman>=1.1.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ scikit-learn
 pyPDF2
 python-docx
 requests
+Flask-Talisman==1.1.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,10 +29,10 @@
         
         
     <!-- htmx -->
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10" nonce="{{ csp_nonce() }}"></script>
     
     <!-- Feather Icons -->
-    <script src="https://unpkg.com/feather-icons"></script>
+    <script src="https://unpkg.com/feather-icons" nonce="{{ csp_nonce() }}"></script>
 </head>
 <body class="d-flex flex-column min-vh-100 bg-dark-blue">
     <!-- Navigation -->
@@ -148,10 +148,10 @@
     </footer>
 
     <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" nonce="{{ csp_nonce() }}"></script>
     
     <!-- PWA Registration -->
-    <script>
+    <script nonce="{{ csp_nonce() }}">
         // Register service worker
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', function() {
@@ -179,10 +179,12 @@
             installDiv.className = 'alert alert-info alert-dismissible fade show';
             installDiv.innerHTML = `
                 <strong>Install App:</strong> Add this app to your home screen for a better experience.
-                <button class="btn btn-sm btn-outline-info ms-2" onclick="installApp()">Install</button>
+                <button class="btn btn-sm btn-outline-info ms-2 install-btn">Install</button>
                 <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
             `;
             document.querySelector('main').prepend(installDiv);
+            const btn = installDiv.querySelector('.install-btn');
+            btn.addEventListener('click', installApp);
         });
 
         function installApp() {
@@ -196,11 +198,11 @@
     </script>
 
     {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.34/moment-timezone-with-data.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.34/moment-timezone-with-data.min.js" nonce="{{ csp_nonce() }}"></script>
     {% endblock %}
     
-    <script>
+    <script nonce="{{ csp_nonce() }}">
         // Auto-hide alert after 5 seconds
         document.addEventListener("DOMContentLoaded", function () {
             const alertBox = document.querySelector(".alert");
@@ -223,7 +225,7 @@
         </div>
     </div>
 
-    <script>
+    <script nonce="{{ csp_nonce() }}">
         function showLoadingOverlay() {
             const overlay = document.getElementById('loadingOverlay');
             if (overlay) {
@@ -231,12 +233,35 @@
                 overlay.style.visibility = 'visible';
             }
         }
-        
+
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.show-loading-overlay').forEach(function(el) {
+                el.addEventListener('click', showLoadingOverlay);
+            });
+
+            document.querySelectorAll('form[data-confirm]').forEach(function(form) {
+                form.addEventListener('submit', function(e) {
+                    const msg = form.getAttribute('data-confirm');
+                    if (!confirm(msg)) {
+                        e.preventDefault();
+                    }
+                });
+            });
+
+            const printBtn = document.getElementById('printBtn');
+            if (printBtn) {
+                printBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    window.print();
+                });
+            }
+        });
+
         // Optional: Hide overlay if back button is used after generation (browser behavior)
         window.addEventListener('pageshow', function(event) {
             if (event.persisted) {
                 const overlay = document.getElementById('loadingOverlay');
-                 if (overlay) {
+                if (overlay) {
                     overlay.style.opacity = 0;
                     overlay.style.visibility = 'hidden';
                 }

--- a/templates/student/change_password.html
+++ b/templates/student/change_password.html
@@ -40,8 +40,4 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
-<script>
-    feather.replace()
-</script>
-{% endblock %} 
+{% block scripts %}{% endblock %}

--- a/templates/student/classroom.html
+++ b/templates/student/classroom.html
@@ -51,7 +51,7 @@
                                         </a>
                                     {% endif %}
                                     <a href="{{ url_for('student_generate_study_guide', classroom_id=classroom.id, material_id=material.id) }}" 
-                                       class="btn btn-outline-light btn-sm" onclick="showLoadingOverlay()">
+                                       class="btn btn-outline-light btn-sm show-loading-overlay">
                                         <i data-feather="book" class="me-1"></i>Study Guide
                                     </a>
                                     <div class="dropdown">
@@ -60,17 +60,17 @@
                                         </button>
                                         <ul class="dropdown-menu dropdown-menu-dark">
                                             <li>
-                                                <a class="dropdown-item text-white" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq', material_id=material.id) }}" onclick="showLoadingOverlay()">
+                                                <a class="dropdown-item text-white show-loading-overlay" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq', material_id=material.id) }}">
                                                     <i data-feather="help-circle" class="me-2 text-white"></i>MCQ Quiz
                                                 </a>
                                             </li>
                                             <li>
-                                                <a class="dropdown-item text-white" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='true_false', material_id=material.id) }}" onclick="showLoadingOverlay()">
+                                                <a class="dropdown-item text-white show-loading-overlay" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='true_false', material_id=material.id) }}">
                                                     <i data-feather="check-circle" class="me-2 text-white"></i>True/False Quiz
                                                 </a>
                                             </li>
                                             <li>
-                                                <a class="dropdown-item text-white" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='essay', material_id=material.id) }}" onclick="showLoadingOverlay()">
+                                                <a class="dropdown-item text-white show-loading-overlay" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='essay', material_id=material.id) }}">
                                                     <i data-feather="edit-3" class="me-2 text-white"></i>Essay Questions
                                                 </a>
                                             </li>
@@ -167,7 +167,7 @@
                     <div class="row g-3">
                         <div class="col-md-6">
                             <div class="d-grid">
-                                <a href="{{ url_for('student_generate_study_guide', classroom_id=classroom.id) }}" class="btn btn-yellow" onclick="showLoadingOverlay()">
+                                <a href="{{ url_for('student_generate_study_guide', classroom_id=classroom.id) }}" class="btn btn-yellow show-loading-overlay">
                                     <i data-feather="book" class="me-2"></i>Generate Study Guide
                                 </a>
                             </div>
@@ -179,17 +179,17 @@
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-dark w-100">
                                     <li>
-                                        <a class="dropdown-item text-white" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq') }}" onclick="showLoadingOverlay()">
+                                        <a class="dropdown-item text-white show-loading-overlay" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq') }}">
                                             <i data-feather="help-circle" class="me-2 text-white"></i>Multiple Choice
                                         </a>
                                     </li>
                                     <li>
-                                        <a class="dropdown-item text-white" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='true_false') }}" onclick="showLoadingOverlay()">
+                                        <a class="dropdown-item text-white show-loading-overlay" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='true_false') }}">
                                             <i data-feather="check-circle" class="me-2 text-white"></i>True/False
                                         </a>
                                     </li>
                                     <li>
-                                        <a class="dropdown-item text-white" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='essay') }}" onclick="showLoadingOverlay()">
+                                        <a class="dropdown-item text-white show-loading-overlay" href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='essay') }}">
                                             <i data-feather="edit-3" class="me-2 text-white"></i>Essay Questions
                                         </a>
                                     </li>

--- a/templates/student/dashboard.html
+++ b/templates/student/dashboard.html
@@ -255,7 +255,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
 // Auto-uppercase invitation code input
 document.getElementById('invitation_code').addEventListener('input', function(e) {
     e.target.value = e.target.value.toUpperCase();

--- a/templates/student/edit_profile.html
+++ b/templates/student/edit_profile.html
@@ -37,7 +37,4 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-    feather.replace()
-</script>
-{% endblock %} 
+{% endblock %}

--- a/templates/student/study_guide.html
+++ b/templates/student/study_guide.html
@@ -9,7 +9,7 @@
         <h5 class="text-white">{{ classroom.name }}</h5>
     </div>
     <div class="d-flex gap-2">
-        <button onclick="window.print()" class="btn btn-outline-light">
+        <button class="btn btn-outline-light" id="printBtn">
             <i data-feather="printer" class="me-2"></i>Print
         </button>
         <a href="{{ url_for('student_classroom', classroom_id=classroom.id) }}" class="btn btn-primary">
@@ -37,11 +37,11 @@
             </small>
             <div class="d-flex gap-2">
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq', material_id=material_id) }}" 
-                   class="btn btn-yellow btn-sm" onclick="showLoadingOverlay()">
+                   class="btn btn-yellow btn-sm show-loading-overlay">
                     <i data-feather="help-circle" class="me-2"></i>Test Your Knowledge
                 </a>
                 <a href="{{ url_for('student_generate_study_guide', classroom_id=classroom.id) }}" 
-                   class="btn btn-outline-light btn-sm" onclick="showLoadingOverlay()">
+                   class="btn btn-outline-light btn-sm show-loading-overlay">
                     <i data-feather="refresh-cw" class="me-2"></i>Generate New Guide
                 </a>
             </div>
@@ -58,7 +58,7 @@
                 <h6 class="text-white">Multiple Choice Quiz</h6>
                 <p class="text-white-80 small">Test your understanding with AI-generated multiple choice questions.</p>
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='mcq', material_id=material_id) }}" 
-                   class="btn btn-outline-light btn-sm" onclick="showLoadingOverlay()">Start Quiz</a>
+                   class="btn btn-outline-light btn-sm show-loading-overlay">Start Quiz</a>
             </div>
         </div>
     </div>
@@ -69,7 +69,7 @@
                 <h6 class="text-white">True/False Quiz</h6>
                 <p class="text-white-80 small">Quick assessment with true or false questions.</p>
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='true_false', material_id=material_id) }}" 
-                   class="btn btn-outline-light btn-sm" onclick="showLoadingOverlay()">Start Quiz</a>
+                   class="btn btn-outline-light btn-sm show-loading-overlay">Start Quiz</a>
             </div>
         </div>
     </div>
@@ -80,7 +80,7 @@
                 <h6 class="text-white">Essay Questions</h6>
                 <p class="text-white-80 small">Practice writing detailed responses to essay questions.</p>
                 <a href="{{ url_for('student_create_quiz', classroom_id=classroom.id, type='essay', material_id=material_id) }}" 
-                   class="btn btn-outline-light btn-sm" onclick="showLoadingOverlay()">Start Quiz</a>
+                   class="btn btn-outline-light btn-sm show-loading-overlay">Start Quiz</a>
             </div>
         </div>
     </div>

--- a/templates/teacher/assignments.html
+++ b/templates/teacher/assignments.html
@@ -64,7 +64,7 @@
                                             <i class="fas fa-edit"></i>
                                         </a>
                                         <form action="{{ url_for('teacher_publish_assignment', assignment_id=assignment.id) }}" method="POST"
-                                              class="d-inline" onsubmit="return confirm('{% if assignment.published %}Unpublish{% else %}Publish{% endif %} this assignment?');">
+                                              class="d-inline" data-confirm="{% if assignment.published %}Unpublish{% else %}Publish{% endif %} this assignment?">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-sm btn-outline-{% if assignment.published %}warning{% else %}success{% endif %}" 
                                                     title="{% if assignment.published %}Unpublish{% else %}Publish{% endif %}">
@@ -76,7 +76,7 @@
                                             <i class="fas fa-list-alt"></i>
                                         </a>
                                         <form action="{{ url_for('teacher_delete_assignment', assignment_id=assignment.id) }}" method="POST"
-                                              class="d-inline" onsubmit='return confirm("Are you sure you want to delete the assignment \"{{ assignment.title }}\"? This action cannot be undone.");'>
+                                              class="d-inline" data-confirm="Are you sure you want to delete the assignment \"{{ assignment.title }}\"? This action cannot be undone.">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
                                                 <i class="fas fa-trash"></i>

--- a/templates/teacher/change_password.html
+++ b/templates/teacher/change_password.html
@@ -40,8 +40,4 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
-<script>
-    feather.replace()
-</script>
-{% endblock %}
+{% block scripts %}{% endblock %}

--- a/templates/teacher/classroom.html
+++ b/templates/teacher/classroom.html
@@ -59,9 +59,9 @@
                                             <i data-feather="download" class="me-1"></i>Download
                                         </a>
                                     {% endif %}
-                                    <form action="{{ url_for('teacher_delete_material', classroom_id=classroom.id, material_id=material.id) }}" method="POST" class="d-inline">
+                                    <form action="{{ url_for('teacher_delete_material', classroom_id=classroom.id, material_id=material.id) }}" method="POST" class="d-inline" data-confirm="Are you sure you want to delete this material?">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Are you sure you want to delete this material?');">
+                                        <button type="submit" class="btn btn-outline-danger btn-sm">
                                             <i data-feather="trash-2" class="me-1"></i>Delete
                                         </button>
                                     </form>
@@ -167,7 +167,7 @@
                                         <i class="fas fa-edit"></i>
                                     </a>
                                     <form action="{{ url_for('teacher_publish_assignment', assignment_id=assignment.id) }}" method="POST"
-                                          class="d-inline" onsubmit="return confirm('{% if assignment.published %}Unpublish{% else %}Publish{% endif %} this assignment?');">
+                                          class="d-inline" data-confirm="{% if assignment.published %}Unpublish{% else %}Publish{% endif %} this assignment?">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <button type="submit" class="btn btn-sm btn-outline-{% if assignment.published %}warning{% else %}success{% endif %}"
                                                 title="{% if assignment.published %}Unpublish{% else %}Publish{% endif %}">
@@ -175,7 +175,7 @@
                                         </button>
                                     </form>
                                     <form action="{{ url_for('teacher_delete_assignment', assignment_id=assignment.id) }}" method="POST"
-                                          class="d-inline" onsubmit="return confirm('Are you sure you want to delete this assignment?');">
+                                          class="d-inline" data-confirm="Are you sure you want to delete this assignment?">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <button type="submit" class="btn btn-outline-danger btn-sm" title="Delete">
                                             <i class="fas fa-trash"></i>
@@ -220,13 +220,13 @@
                                     </div>
                                 </div>
                                 <div class="d-flex gap-2">
-                                    <form action="{{ url_for('teacher_reset_student_password', classroom_id=classroom.id, student_id=student.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to reset the password for {{ student.full_name }}?');">
+                                    <form action="{{ url_for('teacher_reset_student_password', classroom_id=classroom.id, student_id=student.id) }}" method="POST" class="d-inline" data-confirm="Are you sure you want to reset the password for {{ student.full_name }}?">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <button type="submit" class="btn btn-outline-warning btn-sm">
                                             <i class="fas fa-key me-1"></i>Reset Password
                                         </button>
                                     </form>
-                                    <form action="{{ url_for('teacher_remove_student', classroom_id=classroom.id, student_id=student.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to remove {{ student.full_name }} from this classroom?');">
+                                    <form action="{{ url_for('teacher_remove_student', classroom_id=classroom.id, student_id=student.id) }}" method="POST" class="d-inline" data-confirm="Are you sure you want to remove {{ student.full_name }} from this classroom?">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <button type="submit" class="btn btn-outline-danger btn-sm">
                                             <i data-feather="user-minus" class="me-1"></i>

--- a/templates/teacher/create_quiz.html
+++ b/templates/teacher/create_quiz.html
@@ -164,7 +164,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
     document.addEventListener('DOMContentLoaded', function() {
         let questionCounter = 0;
         const questionCountInput = document.getElementById('question_count');

--- a/templates/teacher/edit_profile.html
+++ b/templates/teacher/edit_profile.html
@@ -36,8 +36,4 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
-<script>
-    feather.replace()
-</script>
-{% endblock %}
+{% block scripts %}{% endblock %}

--- a/templates/teacher/edit_quiz.html
+++ b/templates/teacher/edit_quiz.html
@@ -228,7 +228,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
     document.addEventListener('DOMContentLoaded', function() {
         let questionCounter = {{ questions|length }};
         const questionCountInput = document.getElementById('question_count');

--- a/templates/teacher/preview_quiz.html
+++ b/templates/teacher/preview_quiz.html
@@ -188,7 +188,7 @@
     </div>
 
     <div class="text-center mb-4">
-        <form action="{{ url_for('teacher_publish_quiz', quiz_id=quiz.id) }}" method="POST" onsubmit="return confirm('{% if quiz.published %}Unpublish{% else %}Publish{% endif %} this quiz?');">
+        <form action="{{ url_for('teacher_publish_quiz', quiz_id=quiz.id) }}" method="POST" data-confirm="{% if quiz.published %}Unpublish{% else %}Publish{% endif %} this quiz?">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn {% if quiz.published %}btn-warning{% else %}btn-success{% endif %} mr-2">
                 <i class="fas {% if quiz.published %}fa-eye-slash{% else %}fa-check{% endif %}"></i>

--- a/templates/teacher/quizzes.html
+++ b/templates/teacher/quizzes.html
@@ -135,14 +135,14 @@
                                             <i class="fas fa-edit"></i>
                                         </a>
                                         <form action="{{ url_for('teacher_duplicate_quiz', quiz_id=quiz.id) }}" method="POST"
-                                              class="d-inline" onsubmit="return confirm('Duplicate this quiz?');">
+                                              class="d-inline" data-confirm="Duplicate this quiz?">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-sm btn-outline-success" title="Duplicate">
                                                 <i class="fas fa-copy"></i>
                                             </button>
                                         </form>
                                         <form action="{{ url_for('teacher_publish_quiz', quiz_id=quiz.id) }}" method="POST"
-                                              class="d-inline" onsubmit="return confirm('{% if quiz.published %}Unpublish{% else %}Publish{% endif %} this quiz?');">
+                                              class="d-inline" data-confirm="{% if quiz.published %}Unpublish{% else %}Publish{% endif %} this quiz?">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-sm btn-outline-{% if quiz.published %}warning{% else %}success{% endif %}" 
                                                     title="{% if quiz.published %}Unpublish{% else %}Publish{% endif %}">
@@ -151,7 +151,7 @@
                                         </form>
                                         {% if not quiz.published %}
                                         <form action="{{ url_for('teacher_delete_quiz', quiz_id=quiz.id) }}" method="POST"
-                                              class="d-inline" onsubmit='return confirm("Are you sure you want to delete the quiz \"{{ quiz.title }}\"? This action cannot be undone.");'>
+                                              class="d-inline" data-confirm="Are you sure you want to delete the quiz \"{{ quiz.title }}\"? This action cannot be undone.">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
                                                 <i class="fas fa-trash"></i>
@@ -175,7 +175,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce() }}">
     document.addEventListener('DOMContentLoaded', function() {
         // Filter functionality
         const filterButtons = document.querySelectorAll('.filter-btn');

--- a/templates/teacher/results.html
+++ b/templates/teacher/results.html
@@ -201,7 +201,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce() }}">
 "use strict";
 document.addEventListener('DOMContentLoaded', function() {
     const cardViewBtn = document.getElementById('cardViewBtn');


### PR DESCRIPTION
## Summary
- enforce a strict Content Security Policy with Flask-Talisman
- remove inline event handlers and use `data-confirm` / `show-loading-overlay` classes
- add nonces to all script tags so inline scripts comply with CSP
- allow print, loading overlay and confirm prompts via JS in base template
- update requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684585cf0f388326aac8df5e9b4373d4