### PR TITLE
Sanitize AI and markdown HTML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "PyPDF2>=3.0.1",
     "python-docx>=1.1.2",
     "requests>=2.31.0",
+    "bleach>=6.1.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ scikit-learn
 pyPDF2
 python-docx
 requests
+bleach


### PR DESCRIPTION
## Summary
- sanitize rendered Markdown using bleach and allow table and custom attributes
- sanitize AI-generated study guide HTML in routes
- add bleach dependency to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68461b77fdcc83268a091f7ecf0953b6