### PR TITLE
Improve loading overlay controls

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -200,7 +200,7 @@
     height: 100%;
     background-color: rgba(0,0,0,0.7);
     color: white;
-    display: flex;
+    display: none;
     justify-content: center;
     align-items: center;
     z-index: 9999;

--- a/templates/base.html
+++ b/templates/base.html
@@ -227,19 +227,25 @@
         function showLoadingOverlay() {
             const overlay = document.getElementById('loadingOverlay');
             if (overlay) {
+                overlay.style.display = 'flex';
                 overlay.style.opacity = 1;
                 overlay.style.visibility = 'visible';
             }
         }
-        
-        // Optional: Hide overlay if back button is used after generation (browser behavior)
+
+        function hideLoadingOverlay() {
+            const overlay = document.getElementById('loadingOverlay');
+            if (overlay) {
+                overlay.style.display = 'none';
+                overlay.style.opacity = 0;
+                overlay.style.visibility = 'hidden';
+            }
+        }
+
+        // Hide overlay if back button is used after generation (browser behavior)
         window.addEventListener('pageshow', function(event) {
             if (event.persisted) {
-                const overlay = document.getElementById('loadingOverlay');
-                 if (overlay) {
-                    overlay.style.opacity = 0;
-                    overlay.style.visibility = 'hidden';
-                }
+                hideLoadingOverlay();
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- ensure loading overlay uses flex display when shown
- add hideLoadingOverlay for cleanup
- default overlay is hidden via CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68461e0abd6c8326b135b13200edf6a6