### PR TITLE
Add group assignment support

### DIFF
--- a/migrations/versions/32b428bffa0f_group_fields.py
+++ b/migrations/versions/32b428bffa0f_group_fields.py
@@ -1,0 +1,32 @@
+"""group fields
+
+Revision ID: 32b428bffa0f
+Revises: fd787053c267
+Create Date: 2025-06-09 00:28:13.682168
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '32b428bffa0f'
+down_revision = 'fd787053c267'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('assignment', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('allow_group_submission', sa.Boolean(), nullable=True))
+
+    with op.batch_alter_table('assignment_submission', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('group_member_ids', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('assignment_submission', schema=None) as batch_op:
+        batch_op.drop_column('group_member_ids')
+
+    with op.batch_alter_table('assignment', schema=None) as batch_op:
+        batch_op.drop_column('allow_group_submission')

--- a/templates/student/view_assignment.html
+++ b/templates/student/view_assignment.html
@@ -66,6 +66,9 @@
                     {% if submission.feedback %}
                         <p class="mb-0"><strong>Feedback:</strong> {{ submission.feedback | markdown }}</p>
                     {% endif %}
+                    {% if submission.group_members %}
+                        <p class="mb-0"><strong>Group Members:</strong> {{ submission.group_members | map(attribute='full_name') | join(', ') }}</p>
+                    {% endif %}
                     {% if submission.is_resubmission_allowed %}
                         <p class="mb-0 text-success">Teacher has allowed resubmission.</p>
                     {% endif %}
@@ -98,6 +101,17 @@
                             <label for="content" class="form-label">Submit your assignment here:</label>
                             <textarea class="form-control" id="content" name="content" rows="8" required></textarea>
                         </div>
+                        {% if assignment.allow_group_submission %}
+                        <div class="mb-3">
+                            <label class="form-label">Select group members:</label>
+                            {% for classmate in classmates %}
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="group_members" value="{{ classmate.id }}" id="gm{{ classmate.id }}">
+                                    <label class="form-check-label" for="gm{{ classmate.id }}">{{ classmate.full_name }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                         <button type="submit" class="btn btn-primary">Submit Assignment</button>
                     </form>
                 {% else %}

--- a/templates/teacher/assignment_submissions.html
+++ b/templates/teacher/assignment_submissions.html
@@ -19,6 +19,7 @@
                     <thead>
                         <tr>
                             <th>Student</th>
+                            <th>Group Members</th>
                             <th>Submitted On</th>
                             <th>Status</th>
                             <th>Resubmission Allowed</th>
@@ -30,6 +31,11 @@
                         {% for submission in submissions %}
                         <tr>
                             <td>{{ submission.student.full_name }}</td>
+                            <td>
+                                {% if submission.group_members %}
+                                    {{ submission.group_members | map(attribute='full_name') | join(', ') }}
+                                {% else %}-{% endif %}
+                            </td>
                             <td>{{ submission.submitted_at.strftime('%Y-%m-%d %H:%M') }}</td>
                             <td>
                                 {% if submission.status == 'Submitted' %}

--- a/templates/teacher/create_assignment.html
+++ b/templates/teacher/create_assignment.html
@@ -34,6 +34,10 @@
                     <input type="checkbox" class="form-check-input" id="published" name="published">
                     <label class="form-check-label" for="published">Publish Assignment (make visible to students)</label>
                 </div>
+                <div class="form-check mb-3">
+                    <input type="checkbox" class="form-check-input" id="allow_group_submission" name="allow_group_submission">
+                    <label class="form-check-label" for="allow_group_submission">Group assignment?</label>
+                </div>
                 <button type="submit" class="btn btn-primary">
                     <i class="fas fa-plus"></i> Create Assignment
                 </button>

--- a/templates/teacher/edit_assignment.html
+++ b/templates/teacher/edit_assignment.html
@@ -34,6 +34,10 @@
                     <input type="checkbox" class="form-check-input" id="published" name="published" {% if assignment.published %}checked{% endif %}>
                     <label class="form-check-label" for="published">Publish Assignment (make visible to students)</label>
                 </div>
+                <div class="form-check mb-3">
+                    <input type="checkbox" class="form-check-input" id="allow_group_submission" name="allow_group_submission" {% if assignment.allow_group_submission %}checked{% endif %}>
+                    <label class="form-check-label" for="allow_group_submission">Group assignment?</label>
+                </div>
                 <button type="submit" class="btn btn-primary">
                     <i class="fas fa-save"></i> Update Assignment
                 </button>

--- a/templates/teacher/grade_submission.html
+++ b/templates/teacher/grade_submission.html
@@ -23,6 +23,11 @@
                 <dt class="col-sm-3">Student Name:</dt>
                 <dd class="col-sm-9">{{ submission.student.full_name }}</dd>
 
+                {% if submission.group_members %}
+                <dt class="col-sm-3">Group Members:</dt>
+                <dd class="col-sm-9">{{ submission.group_members | map(attribute='full_name') | join(', ') }}</dd>
+                {% endif %}
+
                 <dt class="col-sm-3">Submitted On:</dt>
                 <dd class="col-sm-9">{{ submission.submitted_at.strftime('%Y-%m-%d %H:%M') }}</dd>
 

--- a/tests/test_group_assignment.py
+++ b/tests/test_group_assignment.py
@@ -1,0 +1,68 @@
+import os
+import json
+import unittest
+
+from app import app, db
+from models import User, Classroom, Enrollment, Assignment, AssignmentSubmission
+
+class GroupAssignmentTest(unittest.TestCase):
+    def setUp(self):
+        os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+        os.environ["GEMINI_API_KEY"] = "dummy"
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["TESTING"] = True
+        with app.app_context():
+            db.create_all()
+            teacher = User(email="t@example.com", role="teacher", first_name="T", last_name="Teach")
+            teacher.set_password("pass")
+            s1 = User(email="s1@example.com", role="student", first_name="S1", last_name="Stu")
+            s1.set_password("pass")
+            s2 = User(email="s2@example.com", role="student", first_name="S2", last_name="Stu")
+            s2.set_password("pass")
+            db.session.add_all([teacher, s1, s2])
+            db.session.commit()
+            classroom = Classroom(name="Class", description="", teacher_id=teacher.id)
+            db.session.add(classroom)
+            db.session.commit()
+            db.session.add_all([
+                Enrollment(classroom_id=classroom.id, student_id=s1.id),
+                Enrollment(classroom_id=classroom.id, student_id=s2.id),
+            ])
+            assignment = Assignment(title="A1", classroom_id=classroom.id, teacher_id=teacher.id,
+                                    allow_group_submission=True, published=True)
+            db.session.add(assignment)
+            db.session.commit()
+            self.teacher_id = teacher.id
+            self.student1_id = s1.id
+            self.student2_id = s2.id
+            self.classroom_id = classroom.id
+            self.assignment_id = assignment.id
+
+    def tearDown(self):
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_group_submission_visible_for_all_members(self):
+        with app.app_context():
+            sub = AssignmentSubmission(
+                assignment_id=self.assignment_id,
+                student_id=self.student1_id,
+                content="done",
+                group_member_ids=json.dumps([self.student1_id, self.student2_id])
+            )
+            db.session.add(sub)
+            db.session.commit()
+
+            submissions = AssignmentSubmission.query.filter_by(assignment_id=self.assignment_id).all()
+            found_for_s2 = None
+            for s in submissions:
+                member_ids = json.loads(s.group_member_ids or "[]")
+                if self.student2_id == s.student_id or self.student2_id in member_ids:
+                    found_for_s2 = s
+                    break
+            self.assertIsNotNone(found_for_s2)
+            self.assertEqual(found_for_s2.id, sub.id)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable group submissions with new fields on Assignment and AssignmentSubmission models
- add Alembic migration for the new columns
- update teacher forms to toggle group assignments
- allow students to select group members when submitting
- display group members on teacher review pages
- ensure assignments shown as submitted for all group members
- test group submission visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684629829010832687e2d74cdae2a666