### PR TITLE
Implement CPMK many-to-many relationships

### DIFF
--- a/migrations/versions/af31788a534a_add_cpmk_m2m.py
+++ b/migrations/versions/af31788a534a_add_cpmk_m2m.py
@@ -1,0 +1,56 @@
+"""add association tables for CPMK relations"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'af31788a534a'
+down_revision = 'fd787053c267'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'material_cpmk',
+        sa.Column('material_id', sa.Integer(), nullable=False),
+        sa.Column('cpmk_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['material_id'], ['material.id']),
+        sa.ForeignKeyConstraint(['cpmk_id'], ['cpmk.id']),
+        sa.PrimaryKeyConstraint('material_id', 'cpmk_id')
+    )
+    op.create_table(
+        'quiz_cpmk',
+        sa.Column('quiz_id', sa.Integer(), nullable=False),
+        sa.Column('cpmk_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['quiz_id'], ['quiz.id']),
+        sa.ForeignKeyConstraint(['cpmk_id'], ['cpmk.id']),
+        sa.PrimaryKeyConstraint('quiz_id', 'cpmk_id')
+    )
+    op.create_table(
+        'assignment_cpmk',
+        sa.Column('assignment_id', sa.Integer(), nullable=False),
+        sa.Column('cpmk_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['assignment_id'], ['assignment.id']),
+        sa.ForeignKeyConstraint(['cpmk_id'], ['cpmk.id']),
+        sa.PrimaryKeyConstraint('assignment_id', 'cpmk_id')
+    )
+    with op.batch_alter_table('material', schema=None) as batch_op:
+        batch_op.drop_column('cpmk_id')
+    with op.batch_alter_table('quiz', schema=None) as batch_op:
+        batch_op.drop_column('cpmk_id')
+    with op.batch_alter_table('assignment', schema=None) as batch_op:
+        batch_op.drop_column('cpmk_id')
+
+
+def downgrade():
+    with op.batch_alter_table('assignment', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('cpmk_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, 'cpmk', ['cpmk_id'], ['id'])
+    with op.batch_alter_table('quiz', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('cpmk_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, 'cpmk', ['cpmk_id'], ['id'])
+    with op.batch_alter_table('material', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('cpmk_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, 'cpmk', ['cpmk_id'], ['id'])
+    op.drop_table('assignment_cpmk')
+    op.drop_table('quiz_cpmk')
+    op.drop_table('material_cpmk')

--- a/templates/teacher/classroom.html
+++ b/templates/teacher/classroom.html
@@ -272,9 +272,8 @@
                         <div class="form-text">Supported formats: PDF, TXT, DOC, DOCX (Max 16MB)</div>
                     </div>
                     <div class="mb-3">
-                        <label for="cpmk_id" class="form-label">CPMK</label>
-                        <select class="form-control" id="cpmk_id" name="cpmk_id">
-                            <option value="">-- Select CPMK --</option>
+                        <label for="cpmk_ids" class="form-label">CPMK</label>
+                        <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                             {% for cpmk in cpmks %}
                                 <option value="{{ cpmk.id }}">{{ cpmk.code }}</option>
                             {% endfor %}

--- a/templates/teacher/create_assignment.html
+++ b/templates/teacher/create_assignment.html
@@ -31,9 +31,8 @@
                     <input type="datetime-local" class="form-control" id="deadline" name="deadline">
                 </div>
                 <div class="mb-3">
-                    <label for="cpmk_id" class="form-label">CPMK</label>
-                    <select class="form-control" id="cpmk_id" name="cpmk_id">
-                        <option value="">-- Select CPMK --</option>
+                    <label for="cpmk_ids" class="form-label">CPMK</label>
+                    <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
                             <option value="{{ cpmk.id }}">{{ cpmk.code }}</option>
                         {% endfor %}

--- a/templates/teacher/create_quiz.html
+++ b/templates/teacher/create_quiz.html
@@ -45,9 +45,8 @@
                               placeholder="Explain what this quiz is about and any instructions for students"></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="cpmk_id"><strong>CPMK</strong></label>
-                    <select class="form-control" id="cpmk_id" name="cpmk_id">
-                        <option value="">-- Select CPMK --</option>
+                    <label for="cpmk_ids"><strong>CPMK</strong></label>
+                    <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
                             <option value="{{ cpmk.id }}">{{ cpmk.code }}</option>
                         {% endfor %}

--- a/templates/teacher/edit_assignment.html
+++ b/templates/teacher/edit_assignment.html
@@ -31,11 +31,10 @@
                     <input type="datetime-local" class="form-control" id="deadline" name="deadline" value="{{ assignment.deadline.strftime('%Y-%m-%dT%H:%M') if assignment.deadline else '' }}">
                 </div>
                 <div class="mb-3">
-                    <label for="cpmk_id" class="form-label">CPMK</label>
-                    <select class="form-control" id="cpmk_id" name="cpmk_id">
-                        <option value="">-- Select CPMK --</option>
+                    <label for="cpmk_ids" class="form-label">CPMK</label>
+                    <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
-                            <option value="{{ cpmk.id }}" {% if assignment.cpmk_id == cpmk.id %}selected{% endif %}>{{ cpmk.code }}</option>
+                            <option value="{{ cpmk.id }}" {% if cpmk in assignment.cpmks %}selected{% endif %}>{{ cpmk.code }}</option>
                         {% endfor %}
                     </select>
                 </div>

--- a/templates/teacher/edit_quiz.html
+++ b/templates/teacher/edit_quiz.html
@@ -50,11 +50,10 @@
                               placeholder="Explain what this quiz is about and any instructions for students">{{ quiz.description }}</textarea>
                 </div>
                 <div class="form-group">
-                    <label for="cpmk_id"><strong>CPMK</strong></label>
-                    <select class="form-control" id="cpmk_id" name="cpmk_id">
-                        <option value="">-- Select CPMK --</option>
+                    <label for="cpmk_ids"><strong>CPMK</strong></label>
+                    <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
-                            <option value="{{ cpmk.id }}" {% if quiz.cpmk_id == cpmk.id %}selected{% endif %}>{{ cpmk.code }}</option>
+                            <option value="{{ cpmk.id }}" {% if cpmk in quiz.cpmks %}selected{% endif %}>{{ cpmk.code }}</option>
                         {% endfor %}
                     </select>
                 </div>

--- a/tests/test_cpmk_model.py
+++ b/tests/test_cpmk_model.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+os.environ["GEMINI_API_KEY"] = "dummy"
 from app import app, db
 from models import User, Classroom, CPMK, Material, Quiz, Assignment
 
@@ -27,17 +28,21 @@ class CPMKModelTest(unittest.TestCase):
 
     def test_cpmk_associations(self):
         with app.app_context():
-            cpmk = CPMK(code="C1", description="desc", classroom_id=self.classroom_id)
-            db.session.add(cpmk)
+            c1 = CPMK(code="C1", description="desc", classroom_id=self.classroom_id)
+            c2 = CPMK(code="C2", description="desc2", classroom_id=self.classroom_id)
+            db.session.add_all([c1, c2])
             db.session.commit()
-            material = Material(title="m1", classroom_id=self.classroom_id, cpmk_id=cpmk.id)
-            quiz = Quiz(title="q1", description="", teacher_id=self.teacher_id, classroom_id=self.classroom_id, quiz_type="mcq", questions_json="[]", cpmk_id=cpmk.id)
-            assignment = Assignment(title="a1", classroom_id=self.classroom_id, teacher_id=self.teacher_id, cpmk_id=cpmk.id)
+            material = Material(title="m1", classroom_id=self.classroom_id)
+            material.cpmks = [c1, c2]
+            quiz = Quiz(title="q1", description="", teacher_id=self.teacher_id, classroom_id=self.classroom_id, quiz_type="mcq", questions_json="[]")
+            quiz.cpmks = [c1, c2]
+            assignment = Assignment(title="a1", classroom_id=self.classroom_id, teacher_id=self.teacher_id)
+            assignment.cpmks = [c1, c2]
             db.session.add_all([material, quiz, assignment])
             db.session.commit()
-            self.assertEqual(material.cpmk.id, cpmk.id)
-            self.assertEqual(quiz.cpmk.id, cpmk.id)
-            self.assertEqual(assignment.cpmk.id, cpmk.id)
+            self.assertEqual(set(material.cpmks), {c1, c2})
+            self.assertEqual(set(quiz.cpmks), {c1, c2})
+            self.assertEqual(set(assignment.cpmks), {c1, c2})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_group_assignment.py
+++ b/tests/test_group_assignment.py
@@ -2,13 +2,13 @@ import os
 import json
 import unittest
 
+os.environ["GEMINI_API_KEY"] = "dummy"
 from app import app, db
 from models import User, Classroom, Enrollment, Assignment, AssignmentSubmission
 
 class GroupAssignmentTest(unittest.TestCase):
     def setUp(self):
         os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-        os.environ["GEMINI_API_KEY"] = "dummy"
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
         app.config["TESTING"] = True
         with app.app_context():

--- a/tests/test_quote_context.py
+++ b/tests/test_quote_context.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from unittest.mock import patch
 
+os.environ["GEMINI_API_KEY"] = "dummy"
 from app import app, db, inject_daily_quote
 
 class QuoteContextProcessorTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add material_cpmk, quiz_cpmk and assignment_cpmk association tables
- update models to use many-to-many CPMK relationships
- change CPMK selection in teacher forms to multi-select
- adapt routes to handle multiple CPMKs
- compute CPMK progress via new associations
- provide Alembic migration and update tests

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6846e070440083268301be56c630ff2a