### PR TITLE
Fix placeholder Alembic revision

### DIFF
--- a/migrations/versions/1749444480_add_cpmk_model.py
+++ b/migrations/versions/1749444480_add_cpmk_model.py
@@ -1,9 +1,15 @@
-"""add cpmk model"""
+"""Add cpmk model
+
+Revision ID: 1749444480
+Revises: 32b428bffa0f
+Create Date: 2025-06-09 12:59:48.000000
+
+"""
 from alembic import op
 import sqlalchemy as sa
 
-revision = '${alembic_revision}'
-down_revision = 'fd787053c267'
+revision = '1749444480'
+down_revision = '32b428bffa0f'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- update migration revision ID and down revision

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6846e071fc68832690875b7c71bcf76c