### PR TITLE
Fix missing imports for CPMK association tables

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -13,7 +13,11 @@ from werkzeug.utils import secure_filename
 from werkzeug.exceptions import RequestEntityTooLarge
 from app import app, db
 import logging
-from models import User, Classroom, Enrollment, Material, SelfEvaluation, Quiz, Notification, Assignment, AssignmentSubmission, CPMK
+from models import (
+    User, Classroom, Enrollment, Material, SelfEvaluation, Quiz,
+    Notification, Assignment, AssignmentSubmission, CPMK,
+    quiz_cpmk, assignment_cpmk,
+)
 from awards_utils import calculate_awards_for_student, calculate_star_total, get_classroom_star_rankings
 from ai_service import AIService
 from utils import allowed_file, extract_text_from_file


### PR DESCRIPTION
## Summary
- update the import list in `routes.py` to include `quiz_cpmk` and
  `assignment_cpmk`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: IntegrityError in group assignment test)*

------
https://chatgpt.com/codex/tasks/task_e_6847028d7fb08326b6607ed71b981d1b