### PR TITLE
Update to monochrome codex styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,35 +1,46 @@
 /* Styles extracted from templates */
 
+/* Codex inspired dark theme */
+:root {
+    --accent-color: #10a37f;
+}
+
+body.bg-dark-blue {
+    background-color: #000 !important;
+    color: #f5f5f5;
+}
+
 /* Color scheme overrides */
 .card.gradient-blue {
-    background: linear-gradient(135deg, #219CF3, #1976D2) !important;
+    background: linear-gradient(135deg, #333, #000) !important;
     color: white !important;
 }
 .card.gradient-teal {
-    background: linear-gradient(135deg, #00BCD4, #4DD0E1) !important;
+    background: linear-gradient(135deg, #444, #222) !important;
+    color: white !important;
 }
 .card.gradient-coral {
-    background: linear-gradient(135deg, #FF8A65, #EF5350) !important;
+    background: linear-gradient(135deg, #555, #333) !important;
     color: white !important;
 }
 .btn.btn-gradient-blue {
-    background: linear-gradient(135deg, #219CF3, #1976D2) !important;
+    background-color: #333 !important;
     color: white !important;
     border: none !important;
 }
 .btn.btn-gradient-teal {
-    background-color: #00BCD4 !important;
+    background-color: #444 !important;
     color: white !important;
     border: none !important;
 }
 .btn.btn-yellow {
-    background-color: #FFC107 !important;
-    color: #1976D2 !important;
+    background-color: var(--accent-color) !important;
+    color: #fff !important;
     border: none !important;
     font-weight: bold !important;
 }
 .badge.badge-coral {
-    background-color: #EF5350 !important;
+    background-color: var(--accent-color) !important;
     color: white !important;
 }
 .text-white-80 {
@@ -39,12 +50,12 @@
     color: rgba(255,255,255,0.9) !important;
 }
 .text-yellow {
-    color: #FFC107 !important;
+    color: var(--accent-color) !important;
 }
 
 /* Classroom styles */
 .gradient-blue {
-    background: linear-gradient(to bottom right, #1976D2, #2196F3) !important;
+    background: linear-gradient(135deg, #333, #000) !important;
 }
 .card {
     box-shadow: 0px 2px 6px rgba(0,0,0,0.15);
@@ -72,7 +83,7 @@
     border-radius: 0.5rem !important;
 }
 .modal-content.gradient-blue {
-    background: linear-gradient(to bottom right, #1976D2, #2196F3) !important;
+    background: linear-gradient(135deg, #333, #000) !important;
     color: white !important;
 }
 .modal-content.gradient-blue .form-label,
@@ -90,10 +101,10 @@
     color: rgba(255, 255, 255, 0.6) !important;
 }
 .gradient-purple {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+    background: linear-gradient(135deg, #444, #222) !important;
 }
 .gradient-light-blue {
-    background: linear-gradient(135deg, #64B5F6, #42A5F5) !important;
+    background: linear-gradient(135deg, #555, #333) !important;
     color: white !important;
 }
 
@@ -136,15 +147,15 @@
     border-radius: 0.25rem;
     color: #fff !important;
 }
-.badge.badge-primary { background-color: #0d6efd !important; }
-.badge.badge-secondary { background-color: #17d083 !important; color: #000 !important; }
-.badge.badge-success { background-color: #198754 !important; }
-.badge.badge-danger { background-color: #dc3545 !important; }
-.badge.badge-warning { background-color: #ffc107 !important; color: #000 !important; }
-.badge.badge-info { background-color: #0dcaf0 !important; color: #000 !important; }
-.badge.badge-light { background-color: #f8f9fa !important; color: #000 !important; }
-.badge.badge-dark { background-color: #212529 !important; }
-.badge.badge-coral { background-color: #EF5350 !important; color: white !important; }
+.badge.badge-primary { background-color: var(--accent-color) !important; }
+.badge.badge-secondary { background-color: #555 !important; color: #fff !important; }
+.badge.badge-success { background-color: #666 !important; }
+.badge.badge-danger { background-color: #444 !important; }
+.badge.badge-warning { background-color: #777 !important; color: #fff !important; }
+.badge.badge-info { background-color: #888 !important; color: #fff !important; }
+.badge.badge-light { background-color: #999 !important; color: #000 !important; }
+.badge.badge-dark { background-color: #000 !important; }
+.badge.badge-coral { background-color: var(--accent-color) !important; color: white !important; }
 
 /* Study guide print styles */
 @media print {
@@ -157,14 +168,14 @@
 }
 
 /* Index page hero styles */
-.bg-gradient-blue { background: linear-gradient(135deg, #2196F3, #1976D2); }
-.bg-gradient-cyan { background: linear-gradient(135deg, #03A9F4, #039BE5); }
-.bg-gradient-red { background: linear-gradient(135deg, #FF8A65, #EF5350); }
+.bg-gradient-blue { background: linear-gradient(135deg, #333, #000); }
+.bg-gradient-cyan { background: linear-gradient(135deg, #444, #222); }
+.bg-gradient-red { background: linear-gradient(135deg, #555, #333); }
 .btn-hero { font-weight: 600; border: none; }
-.btn-hero-start { background: linear-gradient(135deg, #2196F3, #1976D2); color: #fff; }
-.btn-hero-start:hover { background: linear-gradient(135deg, #1976D2, #2196F3); color: #fff; }
-.btn-hero-signin { background-color: #00BCD4; color: #fff; }
-.btn-hero-signin:hover { background-color: #0097A7; color: #fff; }
+.btn-hero-start { background-color: var(--accent-color); color: #fff; }
+.btn-hero-start:hover { background-color: var(--accent-color); color: #fff; opacity: 0.9; }
+.btn-hero-signin { background-color: #444; color: #fff; }
+.btn-hero-signin:hover { background-color: #555; color: #fff; }
 
 /* Utility classes for inline styles */
 .icon-48 { width: 48px; height: 48px; }
@@ -173,24 +184,24 @@
 .icon-40 { width: 40px; height: 40px; }
 .icon-14 { width: 14px; height: 14px; }
 
-.bg-dark-blue { background-color: #0b4e91; }
+.bg-dark-blue { background-color: #000; }
 .list-bg-dark { background: rgba(0,0,0,0.3); border-radius: 8px; margin-bottom: 8px; }
 .list-group-flush > .list-bg-dark {
     border-radius: 8px;
 }
 .bg-white-10 { background-color: rgba(255,255,255,0.1); }
 .bg-white-10-border { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); }
-.text-cyan { color: #00BCD4 !important; }
-.text-coral { color: #FF8A65 !important; }
-.text-light-blue { color: #64B5F6 !important; }
+.text-cyan { color: var(--accent-color) !important; }
+.text-coral { color: var(--accent-color) !important; }
+.text-light-blue { color: #ccc !important; }
 .progress-thin { height: 5px; }
 .progress-thin-6 { height: 6px; background-color: rgba(255,255,255,0.2); }
 .progress-small-container { width: 50px; background-color: rgba(0,0,0,0.1); height: 8px; }
-.progress-bar-yellow { background-color: #FFC107; }
+.progress-bar-yellow { background-color: var(--accent-color); }
 .code-inline { background-color: rgba(255,255,255,0.2); padding: 2px 8px; border-radius: 4px; }
 .btn-results { background-color: rgba(255,255,255,0.2); color: white; border: 1px solid rgba(255,255,255,0.3); }
-.badge-cyan { background-color: #00BCD4; color: white; }
-.badge-coral-bg { background-color: #FF8A65; color: white; }
+.badge-cyan { background-color: var(--accent-color); color: white; }
+.badge-coral-bg { background-color: var(--accent-color); color: white; }
 .row-light { border-bottom: 1px solid rgba(0,0,0,0.1); background-color: rgba(255,255,255,0.9); color: #333; }
 .loading-overlay {
     position: fixed;
@@ -215,7 +226,7 @@
 
 /* Custom button styles */
 .btn-outline-white-solid {
-    background: linear-gradient(135deg, #219CF3, #1976D2) !important;
+    background: #333 !important;
     color: white !important;
     border: 1px solid white !important;
 }


### PR DESCRIPTION
## Summary
- switch UI to a black and white "codex" theme
- centralize accent colour via CSS variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684792e4c5588326a91327a02170fca0