### PR TITLE
Show CPMK descriptions in teacher forms

### DIFF
--- a/templates/teacher/create_assignment.html
+++ b/templates/teacher/create_assignment.html
@@ -34,7 +34,7 @@
                     <label for="cpmk_ids" class="form-label">CPMK</label>
                     <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
-                            <option value="{{ cpmk.id }}">{{ cpmk.code }}</option>
+                            <option value="{{ cpmk.id }}">{{ cpmk.code }} - {{ cpmk.description }}</option>
                         {% endfor %}
                     </select>
                 </div>

--- a/templates/teacher/create_quiz.html
+++ b/templates/teacher/create_quiz.html
@@ -48,7 +48,7 @@
                     <label for="cpmk_ids"><strong>CPMK</strong></label>
                     <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
-                            <option value="{{ cpmk.id }}">{{ cpmk.code }}</option>
+                            <option value="{{ cpmk.id }}">{{ cpmk.code }} - {{ cpmk.description }}</option>
                         {% endfor %}
                     </select>
                 </div>

--- a/templates/teacher/edit_assignment.html
+++ b/templates/teacher/edit_assignment.html
@@ -34,7 +34,7 @@
                     <label for="cpmk_ids" class="form-label">CPMK</label>
                     <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
-                            <option value="{{ cpmk.id }}" {% if cpmk in assignment.cpmks %}selected{% endif %}>{{ cpmk.code }}</option>
+                            <option value="{{ cpmk.id }}" {% if cpmk in assignment.cpmks %}selected{% endif %}>{{ cpmk.code }} - {{ cpmk.description }}</option>
                         {% endfor %}
                     </select>
                 </div>

--- a/templates/teacher/edit_quiz.html
+++ b/templates/teacher/edit_quiz.html
@@ -53,7 +53,7 @@
                     <label for="cpmk_ids"><strong>CPMK</strong></label>
                     <select class="form-control" id="cpmk_ids" name="cpmk_ids" multiple>
                         {% for cpmk in cpmks %}
-                            <option value="{{ cpmk.id }}" {% if cpmk in quiz.cpmks %}selected{% endif %}>{{ cpmk.code }}</option>
+                            <option value="{{ cpmk.id }}" {% if cpmk in quiz.cpmks %}selected{% endif %}>{{ cpmk.code }} - {{ cpmk.description }}</option>
                         {% endfor %}
                     </select>
                 </div>


### PR DESCRIPTION
## Summary
- display CPMK descriptions alongside their codes when creating or editing quizzes and assignments

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'markdown')*

------
https://chatgpt.com/codex/tasks/task_e_684814cb5494832681e5f6e0e0df2c11